### PR TITLE
Fix for forestplot 2.0

### DIFF
--- a/tests/testthat/test_rubin.R
+++ b/tests/testthat/test_rubin.R
@@ -143,12 +143,12 @@ test_that("printing works", {
 })
 
 test_that("Forest plots for Rubin model", {
-  expect_is(forest_plot(bg5_n), "vpPath")
-  expect_is(forest_plot(bg5_p), "vpPath")
-  expect_is(forest_plot(bg5_p, show = "posterior"), "vpPath")
-  expect_is(forest_plot(bg5_p, show = "both"), "vpPath")
-  expect_is(forest_plot(bg5_f), "vpPath")
-  expect_is(forest_plot(bg5_f, graph.pos = 1), "vpPath")
+  expect_is(forest_plot(bg5_n), "gforge_forestplot")
+  expect_is(forest_plot(bg5_p), "gforge_forestplot")
+  expect_is(forest_plot(bg5_p, show = "posterior"), "gforge_forestplot")
+  expect_is(forest_plot(bg5_p, show = "both"), "gforge_forestplot")
+  expect_is(forest_plot(bg5_f), "gforge_forestplot")
+  expect_is(forest_plot(bg5_f, graph.pos = 1), "gforge_forestplot")
   expect_error(forest_plot(cars), "baggr objects")
   expect_error(forest_plot(bg5_p, show = "abc"), "should be one of")
 })


### PR DESCRIPTION
I've made some updates in 2.0 and it now returns a list of class gforge_forestplot which causes a test failure for you, merge these fixes and once forestplot 2.0 is up and running you can publish an update. 

The functionality in 2.0 should be identical although now you have the option of using a nicer `dplyr`-inspired syntax.