### PR TITLE
Updating loo_compare documentation and interpretation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ src/RcppExports.cpp
 src/*.h
 /doc/
 /Meta/
+src/Makevars
+src/Makevars.win
+*.so

--- a/R/loocv.R
+++ b/R/loocv.R
@@ -191,8 +191,14 @@ is.baggr_cv <- function(x) {
 #' Given multiple [loocv] outputs, calculate differences in their expected log
 #' predictive density.
 #'
-#' @param x An object of class `baggr_cv` or a list of such objects.
+#' @param x A list of `baggr_cv` objects, with a minimum of 2 objects required for comparison.
+#'          `baggr_cv` objects can be created via the `loocv` method. In instances where a list
+#'          of more than 2 objects is passed, the first model will be compared sequentially to 
+#'          all other provided models.
 #' @param ... Additional objects of class "baggr_cv"
+#' @return  Returns a series of comparisons in order of the list provided as Model 1 - Model N for
+#'          N loocv objects provided. Model 1 corresponds to the first object passed and
+#'          Model N corresponds to the Nth object passed.
 #' @export loo_compare
 #' @seealso [loocv] for fitting LOO CV objects and explanation of the procedure
 #' @examples
@@ -263,6 +269,10 @@ print.compare_baggr_cv <- function(x, digits = 3, ...) {
   class(mat) <- "matrix"
   cat(crayon::bold(paste0("Comparison of cross-validation\n\n")))
   print(signif(mat, digits = digits))
+  cat("\n")
+  cat("Interpretation: A positive ELPD indicates the reference group is a ",
+      "\nmore accurate model, with a larger value indicating a better fit.\n\n")
+
 }
 
 #' Print baggr cv objects nicely
@@ -277,7 +287,7 @@ print.baggr_cv <- function(x, digits = 3, ...) {
   mat <- matrix(nrow = 2, ncol = 2)
 
   mat[1,] <- c(x$elpd, x$se)
-  mat[2,] <- c(x$looic, -2*x$se)
+  mat[2,] <- c(x$looic, abs(-2*x$se))
 
   colnames(mat) <- c("Estimate", "Standard Error")
   rownames(mat) <- c("elpd", "looic")

--- a/R/loocv.R
+++ b/R/loocv.R
@@ -191,14 +191,15 @@ is.baggr_cv <- function(x) {
 #' Given multiple [loocv] outputs, calculate differences in their expected log
 #' predictive density.
 #'
-#' @param x A list of `baggr_cv` objects, with a minimum of 2 objects required for comparison.
-#'          `baggr_cv` objects can be created via the [loocv] function. In instances where a list
-#'          of more than 2 objects is passed, the first model will be compared sequentially to 
-#'          all other provided models.
-#' @param ... Additional objects of class "baggr_cv"
-#' @return  Returns a series of comparisons in order of the list provided as Model 1 - Model N for
+#' @param ... A series of `baggr_cv` objects passed as arguments, with a minimum of 2 
+#'          arguments required for comparison. `baggr_cv` objects can be created via the 
+#'          [loocv] function. In instances where more than 2 arguments are passed, the 
+#'          first model will be compared sequentially to all other provided models.
+#'          Arguments can be passed with names (see example below).
+#' @return  Returns a series of comparisons in order of the arguments provided as Model 1 - Model N for
 #'          N loocv objects provided. Model 1 corresponds to the first object passed and
-#'          Model N corresponds to the Nth object passed.
+#'          Model N corresponds to the Nth object passed. If arguments are passed with names,
+#'          the names will be used instead of Model 1 - Model N. 
 #' @export loo_compare
 #' @seealso [loocv] for fitting LOO CV objects and explanation of the procedure
 #' @examples
@@ -207,25 +208,25 @@ is.baggr_cv <- function(x) {
 #' cv_1 <- loocv(schools, model = "rubin", pooling = "partial")
 #' cv_2 <- loocv(schools, model = "rubin", pooling = "partial",
 #'               prior_hypermean = normal(0, 5), prior_hypersd = cauchy(0,4))
-#' loo_compare(cv_1, cv_2)
+#' loo_compare("cv_1"=cv_1,"cv_2"=cv_2)
 #' }
 #' @export
-loo_compare <- function(x, ...) {
+loo_compare <- function(...) {
   UseMethod("loo_compare")
 }
 
 #' @aliases loo_compare
 #' @export
-loo_compare.baggr_cv <- function(x, ...) {
-  if (is.baggr_cv(x)) {
-    dots <- list(...)
-    loos <- c(list(x), dots)
-  } else {
-    if (!is.list(x) || !length(x)) {
-      stop("'x' must be a list if not a 'loo' object.")
-    }
-    loos <- x
+loo_compare.baggr_cv <- function(...) {
+  l <- list(...)
+  if(all(unlist(lapply(l, class)) == "baggr_cv")) {
+    if(is.null(names(l)))
+      names(l) <- paste("Model", 1:length(l))
+    if(length(unique(names(l))) != length(names(l)))
+      stop("You must use unique model names")
+    loos <- l
   }
+  
   if (!all(sapply(loos, is.baggr_cv))) {
     stop("All inputs should have class 'baggr_cv'.")
   }
@@ -243,18 +244,19 @@ loo_compare.baggr_cv <- function(x, ...) {
   diffs <- list()
 
   for(i in 2:ncol(comp)) {
-    diffname <- paste0("Model 1", " - ", "Model ", i)
+    diffname <- paste0(names(loos)[1], " - ", names(loos)[i])
     rawdiffs <- comp[,1] - comp[,i]
     diffs[[i-1]] <-
       matrix(nrow = 1, ncol = 2,
              c(sum(rawdiffs),
                sqrt(length(rawdiffs))*sd(rawdiffs)),
-             dimnames = list(diffname, c("ELPD", "ELPD SE")))
+             dimnames = list(diffname,c("ELPD", "ELPD SE")))
   }
 
   diffs <- Reduce(rbind, diffs)
   class(diffs) <- c("compare_baggr_cv", class(comp))
   diffs
+
 }
 
 #' Print baggr_cv comparisons

--- a/R/loocv.R
+++ b/R/loocv.R
@@ -192,7 +192,7 @@ is.baggr_cv <- function(x) {
 #' predictive density.
 #'
 #' @param x A list of `baggr_cv` objects, with a minimum of 2 objects required for comparison.
-#'          `baggr_cv` objects can be created via the `loocv` method. In instances where a list
+#'          `baggr_cv` objects can be created via the [loocv] function. In instances where a list
 #'          of more than 2 objects is passed, the first model will be compared sequentially to 
 #'          all other provided models.
 #' @param ... Additional objects of class "baggr_cv"

--- a/man/loo_compare.Rd
+++ b/man/loo_compare.Rd
@@ -8,7 +8,7 @@ loo_compare(x, ...)
 }
 \arguments{
 \item{x}{A list of \code{baggr_cv} objects, with a minimum of 2 objects required for comparison.
-\code{baggr_cv} objects can be created via the \code{loocv} method. In instances where a list
+\code{baggr_cv} objects can be created via the \link{loocv} function. In instances where a list
 of more than 2 objects is passed, the first model will be compared sequentially to
 all other provided models.}
 

--- a/man/loo_compare.Rd
+++ b/man/loo_compare.Rd
@@ -7,9 +7,17 @@
 loo_compare(x, ...)
 }
 \arguments{
-\item{x}{An object of class \code{baggr_cv} or a list of such objects.}
+\item{x}{A list of \code{baggr_cv} objects, with a minimum of 2 objects required for comparison.
+\code{baggr_cv} objects can be created via the \code{loocv} method. In instances where a list
+of more than 2 objects is passed, the first model will be compared sequentially to
+all other provided models.}
 
 \item{...}{Additional objects of class "baggr_cv"}
+}
+\value{
+Returns a series of comparisons in order of the list provided as Model 1 - Model N for
+N loocv objects provided. Model 1 corresponds to the first object passed and
+Model N corresponds to the Nth object passed.
 }
 \description{
 Given multiple \link{loocv} outputs, calculate differences in their expected log

--- a/man/loo_compare.Rd
+++ b/man/loo_compare.Rd
@@ -4,20 +4,20 @@
 \alias{loo_compare}
 \title{Compare LOO CV models}
 \usage{
-loo_compare(x, ...)
+loo_compare(...)
 }
 \arguments{
-\item{x}{A list of \code{baggr_cv} objects, with a minimum of 2 objects required for comparison.
-\code{baggr_cv} objects can be created via the \link{loocv} function. In instances where a list
-of more than 2 objects is passed, the first model will be compared sequentially to
-all other provided models.}
-
-\item{...}{Additional objects of class "baggr_cv"}
+\item{...}{A series of \code{baggr_cv} objects passed as arguments, with a minimum of 2
+arguments required for comparison. \code{baggr_cv} objects can be created via the
+\link{loocv} function. In instances where more than 2 arguments are passed, the
+first model will be compared sequentially to all other provided models.
+Arguments can be passed with names (see example below).}
 }
 \value{
-Returns a series of comparisons in order of the list provided as Model 1 - Model N for
+Returns a series of comparisons in order of the arguments provided as Model 1 - Model N for
 N loocv objects provided. Model 1 corresponds to the first object passed and
-Model N corresponds to the Nth object passed.
+Model N corresponds to the Nth object passed. If arguments are passed with names,
+the names will be used instead of Model 1 - Model N.
 }
 \description{
 Given multiple \link{loocv} outputs, calculate differences in their expected log
@@ -29,7 +29,7 @@ predictive density.
 cv_1 <- loocv(schools, model = "rubin", pooling = "partial")
 cv_2 <- loocv(schools, model = "rubin", pooling = "partial",
               prior_hypermean = normal(0, 5), prior_hypersd = cauchy(0,4))
-loo_compare(cv_1, cv_2)
+loo_compare("cv_1"=cv_1,"cv_2"=cv_2)
 }
 }
 \seealso{


### PR DESCRIPTION
Hi Witold,

Here's a commit that resolves issue #152. I thought the `loocv()` documentation made sense (enough to educate me going in with minimal subject knowledge) and I added a bit to the `loo_compare` documentation. 

I also added an interpretation for the comparisons, which I hope isn't too over simplified, and fixed the negative SE when printing an `loocv` object. 

Best regards,

Danny Toomey