### PR TITLE
Change bg$effects to bg$label and update throughout 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ src/RcppExports.cpp
 src/*.h
 /doc/
 /Meta/
+src/Makevars
+src/Makevars.win
+*.so

--- a/R/baggr.R
+++ b/R/baggr.R
@@ -23,7 +23,7 @@
 #'                        individual-level data. Typically we use either `"none"` or `"partial"`,
 #'                        but if you want to remove the group-specific intercept altogether,
 #'                        set this to `"remove"`.
-#' @param effect Label for effect. Will default to `"mean"` in most cases,
+#' @param label Label for effect. Will default to `"mean"` in most cases,
 #'               `"log OR"` in logistic model,
 #'               quantiles in `quantiles` model etc.
 #'               These labels are used in various print and plot outputs.
@@ -208,7 +208,7 @@
 baggr <- function(data,
                   model = NULL,
                   pooling = c("partial", "none", "full"),
-                  effect = NULL,
+                  label = NULL,
                   covariates = c(),
                   prior_hypermean = NULL, prior_hypersd = NULL, prior_hypercor=NULL,
                   prior_beta = NULL, prior_control = NULL, prior_control_sd = NULL,
@@ -224,6 +224,13 @@ baggr <- function(data,
   # check that it is data.frame of at least 1 row
   # if(!inherits(data, "data.frame") || nrow(data) == 1)
     # stop("data argument must be a data.frame of >1 rows")
+
+  # get label agrument and pass it as effect for compatibility
+  if("effect" %in% attributes(list(...))$names){
+    label <- list(...)$effect
+    message("The 'effect' argument has been renamed 'label'. Please use 'label' insetad of 'effect' in the future")  
+  }
+  effect <- label
 
   # Match arguments
   pooling <- match.arg(pooling)
@@ -351,6 +358,10 @@ baggr <- function(data,
 
   # If extracting prior from another model, we need to do a swapsie switcheroo:
   stan_args <- list(...)
+  # remove effect from stan args if present 
+  if("effect" %in% attributes(stan_args)$names){
+    stan_args$effect <- NULL
+  }
   if("formatted_prior" %in% names(stan_args)){
     formatted_prior <- stan_args$formatted_prior
     stan_args$formatted_prior <- NULL
@@ -386,7 +397,8 @@ baggr <- function(data,
     "formatted_prior" = formatted_prior,
     "n_groups" = n_groups,
     "n_parameters" = n_parameters,
-    "effects" = effect,
+    "label" = effect,
+    #"effects" = effect,
     "covariates" = covariates,
     "pooling" = pooling,
     "fit" = fit,

--- a/R/baggr_compare.R
+++ b/R/baggr_compare.R
@@ -160,7 +160,7 @@ baggr_compare <- function(...,
     compare <- "effects"
   }
 
-  effect_names <- lapply(models, function(x) x$effects)
+  effect_names <- lapply(models, function(x) x$label)
   # quite a mouthful:
   if(!all(
     unlist(

--- a/R/baggr_plot.R
+++ b/R/baggr_plot.R
@@ -43,7 +43,7 @@ baggr_plot <- function(bg, hyper=FALSE,
     return(effect_plot(bg))
   }
   m <- group_effects(bg, transform = transform)
-  effect_labels <- bg$effects
+  effect_labels <- bg$label
 
   if(!(style %in% c("areas", "intervals")))
     stop('plot "style" argument must be one of: "areas", "intervals"')
@@ -64,7 +64,7 @@ baggr_plot <- function(bg, hyper=FALSE,
       mat_to_plot <- m[,,i]
     if(hyper && bg$pooling != "none"){
       ate <- treatment_effect(bg, transform = transform)$tau
-      if(length(bg$effects) > 1) #ATE is a matrix
+      if(length(bg$label) > 1) #ATE is a matrix
         mat_to_plot <- cbind(mat_to_plot, ate[,i])
       else #ATE is a vector
         mat_to_plot <- cbind(mat_to_plot, ate)
@@ -77,7 +77,7 @@ baggr_plot <- function(bg, hyper=FALSE,
                 "intervals" = bayesplot::mcmc_intervals(mat_to_plot, prob = prob,
                                                         prob_outer = prob_outer, ...))
     p +
-      ggplot2::labs(x = paste("Effect on", bg$effects[i])) +
+      ggplot2::labs(x = paste("Effect on", bg$label[i])) +
       baggr_theme_get() +
       {if(hyper & style == "intervals") geom_hline(yintercept = 1.5)} +
       {if(vline) geom_vline(xintercept = vline_value, lty = "dashed")}

--- a/R/effect_draw.R
+++ b/R/effect_draw.R
@@ -63,7 +63,7 @@ effect_draw <- function(object,
   check_if_baggr(x)
 
   # Resize trt effects to the demanded size by making extra draws
-  neffects <- length(x$effects)
+  neffects <- length(x$label)
 
   # Return NA if there is no pooling
   if(x$pooling == "none"){
@@ -224,7 +224,7 @@ effect_plot <- function(..., transform=NULL) {
   # stop("Effect_plot is only possible for models with 1-dimensional treatment effects")
   # effects <- paste("Treatment effect on",
   # unique(unlist(lapply(l, function(x) x$effects))))
-  effects <- unique(unlist(lapply(l, function(x) x$effects)))
+  effects <- unique(unlist(lapply(l, function(x) x$label)))
   n_parameters <- unique(unlist(lapply(l, function(x) x$n_parameters)))
   if(length(n_parameters) != 1)
     stop("All models must have the same number of parameters")

--- a/R/forest_plot.R
+++ b/R/forest_plot.R
@@ -39,7 +39,7 @@ forest_plot <- function(bg,
                         ...) {
   if(!inherits(bg, "baggr"))
     stop("forest_plot can only be used with baggr objects")
-  if(length(bg$effects) > 1)
+  if(length(bg$label) > 1)
     stop("forest_plot only works with 1-dimensional effects")
 
   # Get the summary-level data with tau and se columns
@@ -130,8 +130,8 @@ forest_plot <- function(bg,
   if(show == "covariates"){
     l[["boxsize"]]     <- .15
   }
-  if(!("xlab" %in% names(l)) && bg$effects != "mean")
-    l[["xlab"]] <- bg$effects
+  if(!("xlab" %in% names(l)) && bg$label != "mean")
+    l[["xlab"]] <- bg$label
 
 
   do.call(forestplot, l)

--- a/R/group_effects.R
+++ b/R/group_effects.R
@@ -51,7 +51,7 @@ group_effects <- function(bg, summary = FALSE, transform = NULL, interval = .95,
     par_names <- attr(bg$inputs, "group_label")
 
   # Grab effect names
-  effect_names <- bg$effects
+  effect_names <- bg$label
 
 
 

--- a/R/print_baggr.R
+++ b/R/print_baggr.R
@@ -41,9 +41,9 @@ print.baggr <- function(x,
 
   cat("\n")
 
-  if(length(x$effects) == 1)
+  if(length(x$label) == 1)
     cat(crayon::bold(paste0("Aggregate treatment effect (on ",
-                            x$effects, "), ",
+                            x$label, "), ",
                             x$n_groups," groups:\n")))
   else
     cat(crayon::bold(paste0("Aggregate treatment effects, ",
@@ -66,7 +66,7 @@ print.baggr <- function(x,
     intervaltxt <- paste0("with ", as.character(100*prob), "% interval")
 
     #trim=T avoids whitespace in place of minus sign
-    if(length(x$effects) == 1){
+    if(length(x$label) == 1){
       tau       <- format(mint(te[[1]], int=prob), digits = digits, trim = TRUE)
       sigma_tau <- format(mint(te[[2]], int=prob), digits = digits, trim = TRUE)
 
@@ -88,9 +88,9 @@ print.baggr <- function(x,
         if(!exponent)
           rownames(sigma_tau) <- paste0(100*x$quantiles, "% quantile")
       } else if(x$model == "sslab") {
-        rownames(tau) <- x$effects
+        rownames(tau) <- x$label
         if(!exponent)
-          rownames(sigma_tau) <- x$effects
+          rownames(sigma_tau) <- x$label
       }
 
       print(tau, digits = digits)
@@ -140,9 +140,9 @@ print.baggr <- function(x,
       for(i in 1:dim(study_eff_tab)[3]){
         if(dim(study_eff_tab)[3] > 1 || x$n_groups == 1){
           if(x$n_groups == 1)
-            cat(paste0("Group-specific treatment effect on ", x$effects[i]))
+            cat(paste0("Group-specific treatment effect on ", x$label[i]))
           else
-            cat(paste0("Treatment effects on ", x$effects[i]))
+            cat(paste0("Treatment effects on ", x$label[i]))
         }
 
         if(exponent){
@@ -183,7 +183,7 @@ print.baggr <- function(x,
     cov_names <- dimnames(fixed_eff_tab)[[1]]
 
     for(i in 1:dim(fixed_eff_tab)[3]){
-      cat(paste0("Covariate (fixed) effects on ", x$effects[i]))
+      cat(paste0("Covariate (fixed) effects on ", x$label[i]))
       if(exponent){
         cat(" (converted to exp scale):\n")
         tab <- cbind(fixed_eff_tab[,c("mean", "lci", "uci"),i])

--- a/R/trt_effects.R
+++ b/R/trt_effects.R
@@ -65,8 +65,8 @@ treatment_effect <- function(bg, summary = FALSE,
     stop("Can't calculate treatment effect for this model.")
   }
 
-  if(length(bg$effects) > 1)
-    colnames(tau) <- colnames(sigma_tau) <- bg$effects
+  if(length(bg$label) > 1)
+    colnames(tau) <- colnames(sigma_tau) <- bg$label
 
   if(!is.null(transform)){
     tau <- do.call(transform, list(tau))

--- a/man/baggr.Rd
+++ b/man/baggr.Rd
@@ -8,7 +8,7 @@ baggr(
   data,
   model = NULL,
   pooling = c("partial", "none", "full"),
-  effect = NULL,
+  label = NULL,
   covariates = c(),
   prior_hypermean = NULL,
   prior_hypersd = NULL,
@@ -44,7 +44,7 @@ choose from \code{"none"}, \code{"partial"} (default) and \code{"full"}.
 If you are not familiar with the terms, consult the vignette;
 "partial" can be understood as random effects and "full" as fixed effects}
 
-\item{effect}{Label for effect. Will default to \code{"mean"} in most cases,
+\item{label}{Label for effect. Will default to \code{"mean"} in most cases,
 \code{"log OR"} in logistic model,
 quantiles in \code{quantiles} model etc.
 These labels are used in various print and plot outputs.

--- a/tests/testthat/test_binary.R
+++ b/tests/testthat/test_binary.R
@@ -63,8 +63,8 @@ bg5_rr <- expect_warning(
 test_that("We can run models without prepare_ma'ing data", {
   expect_is(bg5_or, "baggr")
   expect_is(bg5_rr, "baggr")
-  expect_equal(bg5_or$effects, "logOR")
-  expect_equal(bg5_rr$effects, "logRR")
+  expect_equal(bg5_or$label, "logOR")
+  expect_equal(bg5_rr$label, "logRR")
 })
 
 test_that("Various attr of baggr object are correct", {
@@ -73,7 +73,7 @@ test_that("Various attr of baggr object are correct", {
   expect_equal(bg5_f$pooling, "full")
   expect_equal(bg5_p$n_parameters, 1)
   expect_equal(bg5_p$n_groups, 5)
-  expect_equal(bg5_p$effects, "logOR")
+  expect_equal(bg5_p$label, "logOR")
   expect_equal(bg5_p$model, "logit")
   expect_equal(bg5_summarydt$model, "rubin")
   expect_equal(bg5_summarydt$pooling, "partial")

--- a/tests/testthat/test_mutau.R
+++ b/tests/testthat/test_mutau.R
@@ -62,7 +62,7 @@ test_that("Various attr of baggr object are correct", {
   expect_equal(bg5_f$pooling, "full")
   expect_equal(bg5_p$n_parameters, 1)
   expect_equal(bg5_p$n_groups, 8)
-  expect_equal(bg5_p$effects, "mean")
+  expect_equal(bg5_p$label, "mean")
   expect_equal(bg5_p$model, "mutau")
   expect_is(bg5_p$fit, "stanfit")
 })

--- a/tests/testthat/test_rubin.R
+++ b/tests/testthat/test_rubin.R
@@ -77,7 +77,7 @@ test_that("Various attr of baggr object are correct", {
   expect_equal(bg5_f$pooling, "full")
   expect_equal(bg5_p$n_parameters, 1)
   expect_equal(bg5_p$n_groups, 8)
-  expect_equal(bg5_p$effects, "mean")
+  expect_equal(bg5_p$label, "mean")
   expect_equal(bg5_p$model, "rubin")
   expect_is(bg5_p$fit, "stanfit")
 })


### PR DESCRIPTION
Hi Witold,

Here's a commit that resolves issue #150. I changed the `effect` argument in `baggr` to `label` and changed all instances of functions using `bg$effects` to `bg$label`. I kept `effect` as a passable argument to `baggr` for compatibility and added a message requesting use of the new `label` argument. Let me know how this looks!

Best regards,

Danny Toomey