### PR TITLE
Update array syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ LazyData: true
 Biarch: true
 Depends: R (>= 3.5.0), Rcpp (>= 0.12.17)
 Imports: 
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1),
     bayesplot,
     crayon,
@@ -29,8 +29,8 @@ Imports:
     testthat,
     methods
 LinkingTo: 
-    StanHeaders (>= 2.18.1), 
-    rstan (>= 2.18.1), 
+    StanHeaders (>= 2.26.0), 
+    rstan (>= 2.26.0), 
     BH (>= 1.66.0-1), 
     Rcpp (>= 0.12.17), 
     RcppParallel (>= 5.0.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: baggr
 Type: Package
 Title: Bayesian Aggregate Treatment Effects
-Version: 0.7.6
+Version: 0.7.7
 Authors@R: c(person("Witold", "Wiecek", email = "witold.wiecek@gmail.com", role = c("cre", "aut")), 
              person("Rachael", "Meager", role="aut"),
              person("Brice", "Green", role="ctb", comment = "loo_compare, many visuals"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
-# baggr 0.7.6 (March 2022)
+# baggr 0.7.7 (Oct 2023)
 
-* Various CRAN and rstan bugfixes. 
+* Various CRAN and rstan bugfixes. Now that rstan 2.26 is on CRAN, this package requires users to update to it.
 * A few "quality of life"-type and presentation upgrades.
 * You can run meta-analyses with just one row of data, but must specify priors
 

--- a/inst/stan/logit.stan
+++ b/inst/stan/logit.stan
@@ -11,7 +11,7 @@ data {
   int pooling_type; //0 if none, 1 if partial, 2 if full
   int pooling_baseline; //pooling for proportions in control arm;
                         //0 if none, 1 if partial, else no bsl (==0)
-  int<lower=0,upper=K> site[N];
+  array[N] int<lower=0,upper=K> site;
   vector<lower=0,upper=1>[N] treatment;
 
   //priors for baseline parameters
@@ -31,12 +31,12 @@ data {
   int<lower=0> N_test;
   int<lower=0> K_test;
   matrix[N_test, Nc] X_test;
-  int<lower=0, upper=K> test_site[N_test];
+  array[N_test] int<lower=0, upper=K> test_site;
   vector<lower=0, upper=1>[N_test] test_treatment;
 
   //LOGIT-specific:
-  int<lower=0,upper=1> y[N];
-  int<lower=0,upper=1> test_y[N_test];
+  array[N] int<lower=0,upper=1> y;
+  array[N_test] int<lower=0,upper=1> test_y;
 }
 
 transformed data {
@@ -46,10 +46,10 @@ transformed data {
 
 parameters {
   // SHARED ACROSS FULL MODELS:
-  real mu_baseline[pooling_baseline == 1];
-  real mu[pooling_type != 0];
-  real<lower=0> tau_baseline[pooling_baseline == 1];
-  real<lower=0> tau[pooling_type == 1];
+  array[pooling_baseline == 1] real mu_baseline;
+  array[pooling_type != 0] real mu;
+  array[pooling_baseline == 1] real<lower=0> tau_baseline;
+  array[pooling_type == 1] real<lower=0> tau;
   vector[K_pooled] eta;
   vector[K_bsl_pooled] eta_baseline;
   vector[Nc] beta;
@@ -110,7 +110,7 @@ model {
 }
 
 generated quantities {
-  real logpd[K_test > 0];
+  array[K_test > 0] real logpd;
   vector[pooling_type == 1? K_test: 0] theta_k_test;
   vector[N_test] fe_test;
   if(K_test > 0){

--- a/inst/stan/mutau.stan
+++ b/inst/stan/mutau.stan
@@ -5,8 +5,8 @@ functions {
 data {
   int<lower=0> K; // number of sites
   int<lower=2> P; // number of parameters (1 or 2)
-  real theta_hat_k[P,K]; // estimated treatment effects
-  real<lower=0> se_theta_k[P,K]; // s.e. of effect estimates
+  array[P,K] real theta_hat_k; // estimated treatment effects
+  array[P,K] real<lower=0> se_theta_k; // s.e. of effect estimates
   int pooling_type; //0 if none, 1 if partial, 2 if full
   int<lower=0, upper=1> cumsum; //if 1, tau = control + trt effect,
                                 //if 0, tau (TE) does not get added to mu ("control")
@@ -22,8 +22,8 @@ data {
 
   //cross-validation variables:
   int<lower=0> K_test; // number of sites
-  real test_theta_hat_k[P,K_test]; // estimated treatment effects
-  real<lower=0> test_se_theta_k[P,K_test]; // s.e. of effect estimates
+  array[P,K_test] real test_theta_hat_k; // estimated treatment effects
+  array[P,K_test] real<lower=0> test_se_theta_k; // s.e. of effect estimates
 
 }
 
@@ -32,15 +32,15 @@ transformed data {
 }
 
 parameters {
-  vector[P] mu[pooling_type != 0];
-  cholesky_factor_corr[P] L_Omega[pooling_type == 1];
-  vector<lower=0>[P] hypersd[pooling_type == 1];    //  scale
-  matrix[P,K] eta[pooling_type != 2];
+  array[pooling_type != 0] vector[P] mu;
+  array[pooling_type == 1] cholesky_factor_corr[P] L_Omega;
+  array[pooling_type == 1] vector<lower=0>[P] hypersd;    //  scale
+  array[pooling_type != 2] matrix[P,K] eta;
 }
 
 transformed parameters {
-  matrix[P,K] theta_k[pooling_type != 2];
-  matrix[P,P] tau[pooling_type == 1];
+  array[pooling_type != 2] matrix[P,K] theta_k;
+  array[pooling_type == 1] matrix[P,P] tau;
 
   if(pooling_type == 0)
     theta_k[1] = eta[1];
@@ -97,7 +97,7 @@ model {
 }
 
 generated quantities {
-  real logpd[K_test > 0];
+  array[K_test > 0] real logpd;
   if(K_test > 0) {
     logpd[1] = 0;
     for(k in 1:K_test){

--- a/inst/stan/rubin.stan
+++ b/inst/stan/rubin.stan
@@ -34,8 +34,8 @@ transformed data {
 }
 
 parameters {
-  real mu[pooling_type != 0];
-  real<lower=0> tau[pooling_type == 1];
+  array[pooling_type != 0] real mu;
+  array[pooling_type == 1] real<lower=0> tau;
   vector[K_pooled] eta;
   vector[Nc] beta;
 }
@@ -76,7 +76,7 @@ model {
 }
 
 generated quantities {
-  real logpd[K_test > 0];
+  array[K_test > 0] real logpd;
   vector[K_test] fe_k_test;
   if(K_test > 0){
     if(Nc == 0)

--- a/inst/stan/rubin_full.stan
+++ b/inst/stan/rubin_full.stan
@@ -11,7 +11,7 @@ data {
   int pooling_type; //0 if none, 1 if partial, 2 if full
   int pooling_baseline; //pooling for proportions in control arm;
                         //0 if none, 1 if partial, else no bsl (==0)
-  int<lower=0,upper=K> site[N];
+  array[N] int<lower=0,upper=K> site;
   vector<lower=0,upper=1>[N] treatment;
 
   //priors for baseline parameters
@@ -34,13 +34,13 @@ data {
   int<lower=0> N_test;
   int<lower=0> K_test;
   matrix[N_test, Nc] X_test;
-  int<lower=0, upper=K> test_site[N_test];
-  int<lower=0, upper=1> test_treatment[N_test];
+  array[N_test] int<lower=0, upper=K> test_site;
+  array[N_test] int<lower=0, upper=1> test_treatment;
 
   // NORMAL specific:
-  real y[N];
-  real test_y[N_test];
-  real test_sigma_y_k[K_test];
+  array[N] real y;
+  array[N_test] real test_y;
+  array[K_test] real test_sigma_y_k;
 
 }
 
@@ -50,10 +50,10 @@ transformed data {
 }
 parameters {
   // SHARED ACROSS FULL MODELS:
-  real mu_baseline[pooling_baseline == 1];
-  real mu[pooling_type != 0];
-  real<lower=0> tau_baseline[pooling_baseline == 1];
-  real<lower=0> tau[pooling_type == 1];
+  array[pooling_baseline == 1] real mu_baseline;
+  array[pooling_type != 0] real mu;
+  array[pooling_baseline == 1] real<lower=0> tau_baseline;
+  array[pooling_type == 1] real<lower=0> tau;
   vector[K_pooled] eta;
   vector[K_bsl_pooled] eta_baseline;
   vector[Nc] beta;
@@ -117,7 +117,7 @@ model {
 generated quantities {
   // to do this, we must first (outside of Stan) calculate SEs in each test group,
   // i.e. test_sigma_y_k
-  real logpd[K_test > 0];
+  array[K_test > 0] real logpd;
   vector[N_test] fe_test;
   if(K_test > 0){
     if(Nc == 0)


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update your package's Stan models to use the new array syntax, otherwise it will fail to install with an upcoming version of RStan. If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!