### PR TITLE
docs: update README, NEWS and package docs for 2026 (v0.8)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# baggr 0.8 (late 2025)
+# baggr 0.8 (2026)
 
 * You can fit a "typical" selection model on |z| values (a la Hedges 1992) using 
   `selection` argument, e.g. `selection = c(1.96, 2.58)`.

--- a/R/baggr-package.R
+++ b/R/baggr-package.R
@@ -29,7 +29,7 @@
 #' @importFrom rstan sampling
 #'
 #' @references
-#' Stan Development Team (2020). RStan: the R interface to Stan. R package version 2.21.2. https://mc-stan.org
+#' Stan Development Team (2024). RStan: the R interface to Stan. R package version 2.32.6. https://mc-stan.org
 
 #' @keywords internal
 "_PACKAGE"

--- a/man/baggr-package.Rd
+++ b/man/baggr-package.Rd
@@ -29,7 +29,7 @@ try the built-in vignette (\code{vignette("baggr")}).
 }
 
 \references{
-Stan Development Team (2020). RStan: the R interface to Stan. R package version 2.21.2. https://mc-stan.org
+Stan Development Team (2024). RStan: the R interface to Stan. R package version 2.32.6. https://mc-stan.org
 }
 \seealso{
 Useful links:

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# baggr: Bayesian aggregation package for R, v0.7.8 (2024)
+# baggr: Bayesian aggregation package for R, v0.8 (2026)
 
 
 
@@ -94,9 +94,9 @@ example of meta-analysis workflow with `baggr`. If working with binary
 data, try `vignette("baggr_binary")`. Compiled vignettes are available
 [on CRAN](https://cran.r-project.org/web/packages/baggr/index.html).
 
-## Current and future releases
+## Current release
 
-Included in baggr v0.7 (2023):
+Included in baggr v0.8 (2026):
 
   - Meta-analysis of continuous and binary outcomes
   - Both full and aggregate data sets can be used
@@ -108,5 +108,7 @@ Included in baggr v0.7 (2023):
   - Calculation of pooling/heterogeneity metrics
   - Cross-validation (leave-one-group-out)
   - Prior and posterior predictive distributions
+  - Selection models based on \|z\| thresholds (`selection = ...`)
+  - Funnel plots for fitted objects via `funnel()`
 
 Check [NEWS.md] for more information on recent changes to the package.


### PR DESCRIPTION
### Motivation

- Bring package-facing documentation up to date with the 2026 state and current release version (v0.8).
- Replace stale year/version references and highlight features added since older README text (e.g. selection models, funnel plots).
- Ensure package-level documentation references the modern RStan citation/version used by the package docs.

### Description

- Update `readme.md` header to `v0.8 (2026)`, rename the release section to “Current release”, and add bullets for selection models and `funnel()` support.  
- Update top header in `NEWS.md` from “late 2025” to `2026`.  
- Update the Roxygen package documentation source in `R/baggr-package.R` to refresh the RStan citation to `Stan Development Team (2024)` and version `2.32.6`.  
- Keep the generated manual in `man/baggr-package.Rd` consistent by updating the same RStan reference.

### Testing

- Ran targeted text/search checks with `rg` to find stale year/version markers and verify updated files, which confirmed the intended replacements.  
- Displayed the updated file heads (`readme.md`, `NEWS.md`, `R/baggr-package.R`, `man/baggr-package.Rd`) to validate content changes.  
- Attempted an Rd parse check via `Rscript`, but `Rscript` is not available in this environment so the automated Rd parse step could not be run (check failed due to missing `Rscript`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ab820a3c8832a9ccf5dd3a3124bf7)