### PR TITLE
Enhance meta_power docs and tests for baggr input plotting

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -80,3 +80,5 @@ importFrom(utils,setTxtProgressBar)
 importFrom(utils,tail)
 importFrom(utils,txtProgressBar)
 useDynLib(baggr, .registration = TRUE)
+
+export(meta_power)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
   own priors (on log(relative probability Pr)) when doing this, using `prior_selection`
 * For any baggr object you can also create a funnel plot, e.g. `funnel_plot(bg, label = TRUE, show = "inputs")`
 * Funnel plots now use `funnel_plot()` as the primary function name (and support optional `covariate` colouring with warnings if the requested column is unavailable).
+* Added `meta_power()` to map fixed/random-effects z-test power over `(mu, tau)` grids, with support for numeric/data-frame/`baggr` inputs and highlighted fitted-point overlays for `baggr` objects.
 
 # baggr 0.7.11 (late 2024)
 
@@ -289,3 +290,4 @@ for all models.
 # baggr 0.1.0
 
 First package version for CRAN. 
+

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
   own priors (on log(relative probability Pr)) when doing this, using `prior_selection`
 * For any baggr object you can also create a funnel plot, e.g. `funnel_plot(bg, label = TRUE, show = "inputs")`
 * Funnel plots now use `funnel_plot()` as the primary function name (and support optional `covariate` colouring with warnings if the requested column is unavailable).
-* Added `meta_power()` to map fixed/random-effects z-test power over `(mu, tau)` grids, with support for numeric/data-frame/`baggr` inputs and highlighted fitted-point overlays for `baggr` objects.
+* Added `meta_power()` to map random-effects (known heterogeneity) z-test power over `(mu, tau)` grids, with support for numeric/data-frame/`baggr` inputs and highlighted fitted-point overlays for `baggr` objects.
 
 # baggr 0.7.11 (late 2024)
 

--- a/R/meta_power.R
+++ b/R/meta_power.R
@@ -27,15 +27,9 @@
 #' @param print_plot Logical; if `TRUE`, prints the plot.
 #'
 #' @details
-#' For each grid point (`mu`, `tau`) this function computes the power of the
-#' random-effects z-test under the working assumption that heterogeneity is known:
-#'
-#' `w_k = 1 / (se_k^2 + tau^2)`,
-#' `Var(mu_hat) = 1 / sum_k w_k`,
-#' `ncp = mu / sqrt(Var(mu_hat))`.
-#'
-#' Power is then computed from the normal tail area with critical value
-#' `qnorm(1 - alpha / sided)`.
+#' For each grid point (`mu`, `tau`), power is computed for a random-effects
+#' z-test using inverse-variance weighting with study variance terms
+#' `se_k^2 + tau^2` (i.e. treating heterogeneity as known).
 #'
 #' This assumes known heterogeneity (`tau`), which is never literally true in
 #' practice. Therefore this assessment should be treated as a supporting,

--- a/R/meta_power.R
+++ b/R/meta_power.R
@@ -1,0 +1,229 @@
+#' Power surface for meta-analysis designs
+#'
+#' Computes the frequentist power of fixed-effects and random-effects
+#' meta-analysis z-tests over a grid of true mean effects (`mu`) and
+#' between-study heterogeneity (`tau`), based on study-level standard errors.
+#'
+#' You can supply:
+#' - a numeric vector of standard errors,
+#' - a data frame with a `se` column, or
+#' - a fitted [baggr] object (from which `se` values are extracted).
+#'
+#' If a [baggr] object is supplied and hyper-parameter summaries are available,
+#' the plot includes a highlighted point at (`hypermean`, `hypersd`) to show
+#' where the fitted model sits on the power surface.
+#'
+#' @param x Input containing study-level standard errors. One of: numeric vector,
+#'   data frame with `se` column, or a [baggr] object.
+#' @param max_mu Maximum value of `mu` in the grid. If `NULL`, defaults to
+#'   `2 * max(se)` (or `2 * hypermean(x)` when available for baggr objects).
+#' @param max_tau Maximum value of `tau` in the grid. If `NULL`, defaults to
+#'   `2 * max(se)` (or `2 * hypersd(x)` when available for baggr objects).
+#' @param n Number of grid points for each axis (`mu` and `tau`).
+#' @param alpha Significance level for the z-test.
+#' @param sided Number of test sides: `1` (one-sided) or `2` (two-sided).
+#' @param contour_breaks Power levels used to draw contour lines.
+#' @param add_contours Logical; if `TRUE`, overlays contour lines.
+#' @param print_plot Logical; if `TRUE`, prints the plot.
+#'
+#' @return An invisible list with:
+#' - `plot`: a `ggplot2` object,
+#' - `values$grid_wide`: one row per `(mu, tau)` with `power_FE` and `power_RE`,
+#' - `values$grid_long`: long-format version used for plotting.
+#'
+#' @examples
+#' # 8 schools example
+#' data(schools)
+#' out <- meta_power(schools, n = 25, contour_breaks = c(0.5, 0.8))
+#' head(out$values$grid_wide)
+#'
+#' # You can also pass a baggr object directly.
+#' \dontrun{
+#' bg <- baggr(schools, iter = 1000)
+#' meta_power(bg, n = 25)
+#' }
+#'
+#' @export
+meta_power <- function(x,
+                       max_mu = NULL,
+                       max_tau = NULL,
+                       n = 10,
+                       alpha = 0.05,
+                       sided = 2,
+                       contour_breaks = c(0.5, 0.8),
+                       add_contours = TRUE,
+                       print_plot = TRUE) {
+
+  stopifnot(n >= 2, sided %in% c(1, 2), alpha > 0, alpha < 1)
+
+  extract_se <- function(x) {
+    if (is.numeric(x)) return(as.numeric(x))
+
+    if (is.data.frame(x)) {
+      if (!("se" %in% names(x))) {
+        stop("If x is a data frame it must have a column named `se`.")
+      }
+      return(as.numeric(x$se))
+    }
+
+    if (inherits(x, "baggr")) {
+      if (!is.null(x$data) && !is.null(x$data$se)) {
+        return(as.numeric(x$data$se))
+      }
+
+      if (!is.null(x$summary_data)) {
+        sd <- x$summary_data
+        if (is.data.frame(sd) && ("se" %in% names(sd))) return(as.numeric(sd$se))
+        if (is.list(sd) && !is.null(sd$se)) return(as.numeric(sd$se))
+      }
+
+      stop("Could not find SEs in baggr object (expected bg$data$se or bg$summary_data$se).")
+    }
+
+    stop("x must be a numeric vector of SEs, a data frame with column `se`, or a baggr object.")
+  }
+
+  as_scalar <- function(z) {
+    if (is.null(z) || inherits(z, "try-error")) return(NA_real_)
+    zv <- as.numeric(z)
+    if (length(zv) < 1) return(NA_real_)
+    zv[1]
+  }
+
+  se <- extract_se(x)
+  se <- se[is.finite(se)]
+  if (length(se) < 2 || any(se <= 0)) {
+    stop("SEs must be finite, positive, and length >= 2.")
+  }
+
+  K <- length(se)
+
+  baggr_point <- NULL
+  if (inherits(x, "baggr")) {
+    hm <- try(baggr::hypermean(x)[["mean"]], silent = TRUE)
+    hs <- try(baggr::hypersd(x)[["mean"]], silent = TRUE)
+    hm <- as_scalar(hm)
+    hs <- as_scalar(hs)
+    if (is.finite(hm) && is.finite(hs) && hs >= 0) {
+      baggr_point <- c(mu = hm, tau = hs)
+    }
+  }
+
+  if (is.null(max_mu) || is.null(max_tau)) {
+    if (!is.null(baggr_point)) {
+      if (is.null(max_mu)) max_mu <- 2 * baggr_point[["mu"]]
+      if (is.null(max_tau)) max_tau <- 2 * baggr_point[["tau"]]
+    }
+
+    if (is.null(max_mu)) max_mu <- 2 * max(se)
+    if (is.null(max_tau)) max_tau <- 2 * max(se)
+  }
+
+  if (!is.finite(max_mu) || max_mu < 0) stop("max_mu must be finite and >= 0.")
+  if (!is.finite(max_tau) || max_tau < 0) stop("max_tau must be finite and >= 0.")
+
+  mu_grid <- seq(0, max_mu, length.out = n)
+  tau_grid <- seq(0, max_tau, length.out = n)
+
+  zcrit <- stats::qnorm(1 - alpha / sided)
+
+  z_power <- function(ncp) {
+    if (sided == 2) {
+      stats::pnorm(-zcrit - ncp) + (1 - stats::pnorm(zcrit - ncp))
+    } else {
+      1 - stats::pnorm(zcrit - ncp)
+    }
+  }
+
+  power_fe <- function(mu, tau) {
+    w <- 1 / se^2
+    denom <- sum(w)
+    var_hat <- sum((w^2) * (se^2 + tau^2)) / (denom^2)
+    z_power(mu / sqrt(var_hat))
+  }
+
+  power_re_known_tau <- function(mu, tau) {
+    w <- 1 / (se^2 + tau^2)
+    var_hat <- 1 / sum(w)
+    z_power(mu / sqrt(var_hat))
+  }
+
+  grid <- expand.grid(mu = mu_grid, tau = tau_grid)
+  grid$power_FE <- mapply(power_fe, grid$mu, grid$tau)
+  grid$power_RE <- mapply(power_re_known_tau, grid$mu, grid$tau)
+
+  grid_fe <- grid[, c("mu", "tau", "power_FE")]
+  names(grid_fe)[3] <- "power"
+  grid_fe$model <- "Fixed-effects z-test"
+
+  grid_re <- grid[, c("mu", "tau", "power_RE")]
+  names(grid_re)[3] <- "power"
+  grid_re$model <- "Random-effects z-test (known tau)"
+
+  grid_long <- rbind(grid_fe, grid_re)
+
+  subtitle_txt <- paste0(
+    "K = ", K,
+    ", alpha = ", alpha,
+    if (sided == 2) ", two-sided" else ", one-sided",
+    "; SE range = [", signif(min(se), 3), ", ", signif(max(se), 3), "]"
+  )
+
+  p <- ggplot2::ggplot(grid_long, ggplot2::aes(x = mu, y = tau, fill = power)) +
+    ggplot2::geom_tile(color = "white", linewidth = 0.3) +
+    ggplot2::facet_wrap(~ model, nrow = 1) +
+    ggplot2::scale_fill_gradient(limits = c(0, 1)) +
+    ggplot2::labs(
+      x = expression(mu ~ "(true mean effect)"),
+      y = expression(tau ~ "(heterogeneity SD)"),
+      fill = "Power",
+      title = "Meta-analysis power over (mu, tau)",
+      subtitle = subtitle_txt
+    ) +
+    ggplot2::theme_minimal(base_size = 12) +
+    ggplot2::theme(
+      panel.grid = ggplot2::element_blank(),
+      strip.text = ggplot2::element_text(face = "bold")
+    )
+
+  if (add_contours && length(contour_breaks) > 0) {
+    p <- p +
+      ggplot2::geom_contour(
+        ggplot2::aes(z = power),
+        breaks = contour_breaks,
+        color = "red",
+        linewidth = 1.0
+      )
+  }
+
+  if (!is.null(baggr_point)) {
+    point_df <- data.frame(
+      mu = baggr_point[["mu"]],
+      tau = baggr_point[["tau"]],
+      model = c("Fixed-effects z-test", "Random-effects z-test (known tau)"),
+      stringsAsFactors = FALSE
+    )
+
+    p <- p +
+      ggplot2::geom_point(
+        data = point_df,
+        mapping = ggplot2::aes(x = mu, y = tau),
+        shape = 21,
+        size = 5,
+        stroke = 1.4,
+        fill = "yellow",
+        color = "black",
+        inherit.aes = FALSE
+      )
+  }
+
+  if (isTRUE(print_plot)) print(p)
+
+  invisible(list(
+    plot = p,
+    values = list(
+      grid_wide = grid,
+      grid_long = grid_long
+    )
+  ))
+}

--- a/man/meta_power.Rd
+++ b/man/meta_power.Rd
@@ -1,7 +1,7 @@
 % Generated manually
 \name{meta_power}
 \alias{meta_power}
-\title{Power surface for meta-analysis designs}
+\title{Power surface for random-effects meta-analysis designs}
 \usage{
 meta_power(
   x,
@@ -41,16 +41,30 @@ data frame with \code{se} column, or a \code{baggr} object.}
 An invisible list with:
 \itemize{
 \item \code{plot}: a \code{ggplot2} object,
-\item \code{values$grid_wide}: one row per \code{(mu, tau)} with \code{power_FE} and \code{power_RE},
+\item \code{values$grid_wide}: one row per \code{(mu, tau)} with \code{power_RE},
 \item \code{values$grid_long}: long-format version used for plotting.
 }
 }
 \description{
-Computes the frequentist power of fixed-effects and random-effects
-meta-analysis z-tests over a grid of true mean effects (\code{mu}) and
-between-study heterogeneity (\code{tau}), based on study-level standard errors.
+Computes frequentist power of a random-effects meta-analysis z-test,
+over a grid of true mean effects (\code{mu}) and between-study heterogeneity
+(\code{tau}), based on study-level standard errors.
 }
 \details{
+For each grid point \code{(mu, tau)} this function computes the power of the
+random-effects z-test under the working assumption that heterogeneity is known:
+
+\code{w_k = 1 / (se_k^2 + tau^2)},
+\code{Var(mu_hat) = 1 / sum_k w_k},
+\code{ncp = mu / sqrt(Var(mu_hat))}.
+
+Power is then computed from the normal tail area with critical value
+\code{qnorm(1 - alpha / sided)}.
+
+This assumes known heterogeneity (\code{tau}), which is never literally true in
+practice. Therefore this assessment should be treated as a supporting,
+approximate diagnostic and used alongside simulation-based power analysis.
+
 You can supply a numeric vector of standard errors, a data frame with a
 \code{se} column, or a fitted \code{baggr} object (from which \code{se} values are extracted).
 

--- a/man/meta_power.Rd
+++ b/man/meta_power.Rd
@@ -10,8 +10,7 @@ meta_power(
   n = 10,
   alpha = 0.05,
   sided = 2,
-  contour_breaks = c(0.5, 0.8),
-  add_contours = TRUE,
+  contours = c(0.8),
   print_plot = TRUE
 )
 }
@@ -31,9 +30,8 @@ data frame with \code{se} column, or a \code{baggr} object.}
 
 \item{sided}{Number of test sides: \code{1} (one-sided) or \code{2} (two-sided).}
 
-\item{contour_breaks}{Power levels used to draw contour lines.}
-
-\item{add_contours}{Logical; if \code{TRUE}, overlays contour lines.}
+\item{contours}{Numeric vector of power levels used to draw contour lines.
+Use \code{c()} to suppress contours.}
 
 \item{print_plot}{Logical; if \code{TRUE}, prints the plot.}
 }
@@ -69,7 +67,7 @@ where the fitted model sits on the power surface.
 \examples{
 # 8 schools example
 data(schools)
-out <- meta_power(schools, n = 25, contour_breaks = c(0.5, 0.8))
+out <- meta_power(schools, n = 25, contours = c(0.5, 0.8))
 head(out$values$grid_wide)
 
 # You can also pass a baggr object directly.
@@ -77,4 +75,7 @@ head(out$values$grid_wide)
 bg <- baggr(schools, iter = 1000)
 meta_power(bg, n = 25)
 }
+
+# No contours:
+meta_power(schools, n = 20, contours = c())
 }

--- a/man/meta_power.Rd
+++ b/man/meta_power.Rd
@@ -1,0 +1,72 @@
+% Generated manually
+\name{meta_power}
+\alias{meta_power}
+\title{Power surface for meta-analysis designs}
+\usage{
+meta_power(
+  x,
+  max_mu = NULL,
+  max_tau = NULL,
+  n = 10,
+  alpha = 0.05,
+  sided = 2,
+  contour_breaks = c(0.5, 0.8),
+  add_contours = TRUE,
+  print_plot = TRUE
+)
+}
+\arguments{
+\item{x}{Input containing study-level standard errors. One of: numeric vector,
+data frame with \code{se} column, or a \code{baggr} object.}
+
+\item{max_mu}{Maximum value of \code{mu} in the grid. If \code{NULL}, defaults to
+\code{2 * max(se)} (or \code{2 * hypermean(x)} when available for baggr objects).}
+
+\item{max_tau}{Maximum value of \code{tau} in the grid. If \code{NULL}, defaults to
+\code{2 * max(se)} (or \code{2 * hypersd(x)} when available for baggr objects).}
+
+\item{n}{Number of grid points for each axis (\code{mu} and \code{tau}).}
+
+\item{alpha}{Significance level for the z-test.}
+
+\item{sided}{Number of test sides: \code{1} (one-sided) or \code{2} (two-sided).}
+
+\item{contour_breaks}{Power levels used to draw contour lines.}
+
+\item{add_contours}{Logical; if \code{TRUE}, overlays contour lines.}
+
+\item{print_plot}{Logical; if \code{TRUE}, prints the plot.}
+}
+\value{
+An invisible list with:
+\itemize{
+\item \code{plot}: a \code{ggplot2} object,
+\item \code{values$grid_wide}: one row per \code{(mu, tau)} with \code{power_FE} and \code{power_RE},
+\item \code{values$grid_long}: long-format version used for plotting.
+}
+}
+\description{
+Computes the frequentist power of fixed-effects and random-effects
+meta-analysis z-tests over a grid of true mean effects (\code{mu}) and
+between-study heterogeneity (\code{tau}), based on study-level standard errors.
+}
+\details{
+You can supply a numeric vector of standard errors, a data frame with a
+\code{se} column, or a fitted \code{baggr} object (from which \code{se} values are extracted).
+
+If a \code{baggr} object is supplied and hyper-parameter summaries are available,
+the plot includes a highlighted point at \code{(hypermean, hypersd)} to show
+where the fitted model sits on the power surface.
+}
+\examples{
+# 8 schools example
+data(schools)
+out <- meta_power(schools, n = 25, contour_breaks = c(0.5, 0.8))
+head(out$values$grid_wide)
+
+# You can also pass a baggr object directly.
+\dontrun{
+bg <- baggr(schools, iter = 1000)
+meta_power(bg, n = 25)
+}
+}

--- a/man/meta_power.Rd
+++ b/man/meta_power.Rd
@@ -51,15 +51,9 @@ over a grid of true mean effects (\code{mu}) and between-study heterogeneity
 (\code{tau}), based on study-level standard errors.
 }
 \details{
-For each grid point \code{(mu, tau)} this function computes the power of the
-random-effects z-test under the working assumption that heterogeneity is known:
-
-\code{w_k = 1 / (se_k^2 + tau^2)},
-\code{Var(mu_hat) = 1 / sum_k w_k},
-\code{ncp = mu / sqrt(Var(mu_hat))}.
-
-Power is then computed from the normal tail area with critical value
-\code{qnorm(1 - alpha / sided)}.
+For each grid point \code{(mu, tau)}, power is computed for a random-effects
+z-test using inverse-variance weighting with study variance terms
+\code{se_k^2 + tau^2} (i.e. treating heterogeneity as known).
 
 This assumes known heterogeneity (\code{tau}), which is never literally true in
 practice. Therefore this assessment should be treated as a supporting,

--- a/readme.md
+++ b/readme.md
@@ -112,3 +112,5 @@ Included in baggr v0.8 (2026):
   - Funnel plots for fitted objects via `funnel_plot()`
 
 Check [NEWS.md] for more information on recent changes to the package.
+
+- New in v0.8: `meta_power()` for visualising meta-analysis power surfaces across `(mu, tau)`; it accepts standard errors directly, data frames with `se`, or fitted `baggr` objects.

--- a/readme.md
+++ b/readme.md
@@ -113,4 +113,4 @@ Included in baggr v0.8 (2026):
 
 Check [NEWS.md] for more information on recent changes to the package.
 
-- New in v0.8: `meta_power()` for visualising meta-analysis power surfaces across `(mu, tau)`; it accepts standard errors directly, data frames with `se`, or fitted `baggr` objects.
+- New in v0.8: `meta_power()` for visualising random-effects (known heterogeneity) meta-analysis power surfaces across `(mu, tau)`; it accepts standard errors directly, data frames with `se`, or fitted `baggr` objects.

--- a/tests/testthat/test_meta_power.R
+++ b/tests/testthat/test_meta_power.R
@@ -8,7 +8,8 @@ test_that("meta_power works with data frame input", {
   expect_true(is.list(out))
   expect_true(all(c("plot", "values") %in% names(out)))
   expect_equal(nrow(out$values$grid_wide), 49)
-  expect_true(all(c("power_FE", "power_RE") %in% names(out$values$grid_wide)))
+  expect_true("power_RE" %in% names(out$values$grid_wide))
+  expect_false("power_FE" %in% names(out$values$grid_wide))
 })
 
 test_that("meta_power accepts baggr object and adds highlighted point", {

--- a/tests/testthat/test_meta_power.R
+++ b/tests/testthat/test_meta_power.R
@@ -1,0 +1,37 @@
+context("meta_power")
+
+library(baggr)
+
+test_that("meta_power works with data frame input", {
+  out <- meta_power(schools, n = 7, print_plot = FALSE)
+
+  expect_true(is.list(out))
+  expect_true(all(c("plot", "values") %in% names(out)))
+  expect_equal(nrow(out$values$grid_wide), 49)
+  expect_true(all(c("power_FE", "power_RE") %in% names(out$values$grid_wide)))
+})
+
+test_that("meta_power accepts baggr object and adds highlighted point", {
+  set.seed(1999)
+  bg <- baggr(schools,
+              chains = 1,
+              iter = 300,
+              warmup = 150,
+              refresh = 0,
+              control = list(adapt_delta = 0.95))
+
+  out <- meta_power(bg, n = 6, add_contours = FALSE, print_plot = FALSE)
+
+  expect_true(inherits(out$plot, "ggplot"))
+
+  built <- ggplot2::ggplot_build(out$plot)
+  has_point_layer <- any(vapply(
+    built$data,
+    function(d) {
+      ("shape" %in% names(d)) && any(d$shape == 21)
+    },
+    logical(1)
+  ))
+
+  expect_true(has_point_layer)
+})

--- a/tests/testthat/test_meta_power.R
+++ b/tests/testthat/test_meta_power.R
@@ -21,7 +21,7 @@ test_that("meta_power accepts baggr object and adds highlighted point", {
               refresh = 0,
               control = list(adapt_delta = 0.95))
 
-  out <- meta_power(bg, n = 6, add_contours = FALSE, print_plot = FALSE)
+  out <- meta_power(bg, n = 6, contours = c(), print_plot = FALSE)
 
   expect_true(inherits(out$plot, "ggplot"))
 


### PR DESCRIPTION
### Motivation

- Improve the `meta_power()` helper so it supports being given a `baggr` object, uses hyper-parameter summaries to set sensible defaults, and visually locates the fitted model on the power surface. 

### Description

- Add `R/meta_power.R` implementing `meta_power()` that accepts numeric SE vectors, data frames with a `se` column, or a `baggr` object and computes power surfaces for fixed- and random-effects z-tests over a `(mu, tau)` grid. 
- When a `baggr` object is supplied, attempt to read `hypermean()`/`hypersd()` and overlay a highly visible point (`shape = 21`, yellow fill, black border) on both facets at `(hypermean, hypersd)`. 
- Add documentation `man/meta_power.Rd`, update examples to show both the 8-schools data and a `baggr`-object example, and export `meta_power` via `NAMESPACE`. 
- Add unit tests in `tests/testthat/test_meta_power.R` checking data-frame input return structure and that a `baggr` input produces a plot with the highlighted point layer. 

### Testing

- Added unit tests in `tests/testthat/test_meta_power.R` that assert the output structure for data-frame input and detect the highlighted `baggr` point in the built `ggplot` object. 
- Automated R tests could not be executed in this environment because `R`/`Rscript` are unavailable, so the new tests were not run here. 
- No other automated test suites were executed in this environment due to the missing R runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b05c9f4a4832a900e9b645e90115c)