### PR TITLE
Handle fixed-within-study covariates as meta-regression inputs

### DIFF
--- a/R/baggr.R
+++ b/R/baggr.R
@@ -439,7 +439,7 @@ baggr <- function(data,
 
   attr(result, "ppd") <- ppd
 
-  if(grepl("individual", attr(stan_data, "data_type")))
+  if(grepl("individual", attr(stan_data, "data_type"))) {
     result$summary_data <- prepare_ma(data,
                                       # rare_event_correction = 0.5,
                                       effect = ifelse(model == "logit", "logOR", "mean"),
@@ -447,6 +447,14 @@ baggr <- function(data,
                                       treatment = attr(data, "treatment"),
                                       outcome = attr(data, "outcome"),
                                       pooling = TRUE)
+
+    mr_covariates <- attr(stan_data, "meta_regression_covariates")
+    if(length(mr_covariates) > 0)
+      result$summary_data <- cbind(result$summary_data,
+                                   data[match(result$summary_data$group, data[[attr(data, "group")]]),
+                                        mr_covariates,
+                                        drop = FALSE])
+  }
 
   if(model == "quantiles")
     result[["quantiles"]]    <- quantiles

--- a/tests/testthat/test_full.R
+++ b/tests/testthat/test_full.R
@@ -200,10 +200,14 @@ test_that("Within-study varying covariates are reported as not meta-regression",
   sa_vary <- schools_ipd
   sa_vary$ind_cov <- rnorm(nrow(sa_vary))
 
-  expect_message(
-    baggr(sa_vary, covariates = c("ind_cov"), iter = 150, chains = 1, refresh = 0),
+  bg_cov_vary <- expect_message(
+    suppressWarnings(
+      baggr(sa_vary, covariates = c("ind_cov"),
+            iter = 150, chains = 1, refresh = 0, warn = FALSE)
+    ),
     "Covariate ind_cov varies within studies. Model fitting will work but is not a meta-regression."
   )
+  expect_is(bg_cov_vary, "baggr")
 })
 bg_pr <- expect_warning(baggr(schools_ipd,
                               pooling = "partial",

--- a/tests/testthat/test_full.R
+++ b/tests/testthat/test_full.R
@@ -181,6 +181,30 @@ test_that("Model with covariates works fine", {
   expect_equal(dim(fixed_effects(bg_cov, summary = FALSE))[2], 4)
 })
 
+
+
+test_that("Fixed within-study covariates are added to summary_data", {
+  sa_fixed <- schools_ipd
+  sa_fixed$site_cov <- as.numeric(factor(sa_fixed$group))
+  bg_cov_fixed <- expect_warning(
+    baggr(sa_fixed, covariates = c("site_cov"), iter = 150, chains = 1, refresh = 0)
+  )
+
+  expect_true("site_cov" %in% names(bg_cov_fixed$summary_data))
+  expected <- sa_fixed$site_cov[match(bg_cov_fixed$summary_data$group, sa_fixed$group)]
+  expect_equal(bg_cov_fixed$summary_data$site_cov, expected)
+})
+
+
+test_that("Within-study varying covariates are reported as not meta-regression", {
+  sa_vary <- schools_ipd
+  sa_vary$ind_cov <- rnorm(nrow(sa_vary))
+
+  expect_message(
+    baggr(sa_vary, covariates = c("ind_cov"), iter = 150, chains = 1, refresh = 0),
+    "Covariate ind_cov varies within studies. Model fitting will work but is not a meta-regression."
+  )
+})
 bg_pr <- expect_warning(baggr(schools_ipd,
                               pooling = "partial",
                               pooling_control = "remove",


### PR DESCRIPTION
### Motivation
- Ensure covariates supplied for models that derive `summary_data` are only treated as meta-regression predictors when they are fixed within each study (so the meta-regression interpretation is valid).
- When a covariate varies within studies, warn the user that fitting will proceed but it is not a meta-regression and avoid adding that covariate to the summary-level matrix.

### Description
- Added per-covariate detection in `convert_inputs()` that, for individual-level data, checks whether each covariate is fixed within study using `tapply(..., function(x) length(unique(x)) == 1)`, emits the message `Covariate [name] varies within studies. Model fitting will work but is not a meta-regression.` for varying covariates, and collects fixed covariates as `meta_regression_covariates` in the returned input structure.
- Updated `convert_inputs()` to include the `meta_regression_covariates` attribute on the prepared input structure (key: `meta_regression_covariates`).
- Updated `baggr()` so that when `summary_data` is produced from individual-level inputs it appends only the `meta_regression_covariates` columns to the `summary_data` (matching by group) so summary-level matrices include only covariates that are fixed within studies.
- Added two `testthat` cases in `tests/testthat/test_full.R` to verify that fixed covariates are appended to `summary_data` and that varying covariates trigger the new message.

### Testing
- Attempted to run the new targeted `testthat` cases via `Rscript -e "testthat::test_file(... )"`, but the environment lacks `Rscript` so the automated tests could not be executed here (failed with `Rscript: command not found`).
- Confirmed code changes were staged and committed (`git commit` succeeded) but no further automated test runs completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b2a214120832aade30e0c0ed04d98)