### PR TITLE
Adjust logit control prior messaging by baseline pooling

### DIFF
--- a/R/auto_prior.R
+++ b/R/auto_prior.R
@@ -209,11 +209,19 @@ prepare_prior <- function(prior,
           }
         } else if(current_prior == "control") {
           if(model == "logit"){
-            prop_ctrl <- data$c / (data$c + data$d)
-            if(max(prop_ctrl) > .999 | min(prop_ctrl) < .001)
-              message("Baseline proportion of events is very close to 0 or 1.",
-                      "Consider manually setting prior_control.")
-            special_name <- "log odds of event rate in untreated: mean"
+            if(stan_data$pooling_baseline != 2) {
+              prop_ctrl <- data$c / (data$c + data$d)
+              if(max(prop_ctrl) > .999 | min(prop_ctrl) < .001)
+                message("Baseline proportion of events is very close to 0 or 1.",
+                        "Consider manually setting prior_control.")
+            }
+
+            if(stan_data$pooling_baseline == 1)
+              special_name <- "log odds of event rate in untreated: mean"
+            else if(stan_data$pooling_baseline == 0)
+              special_name <- "independent prior on control means (group-specific baseline log-odds)"
+            else
+              special_name <- "DNP"
           }
           if(model %in% c("rubin_full", "mutau_full")){
             if(stan_data$pooling_baseline == 1)


### PR DESCRIPTION
### Motivation
- Ensure the user-facing prior messaging for the `control` prior in `logit` models reflects the `stan_data$pooling_baseline` setting and suppress the line when the baseline is removed.

### Description
- Updated the `current_prior == "control"` branch in `R/auto_prior.R` to consult `stan_data$pooling_baseline` for `model == "logit"`.
- Wrapped the extreme baseline proportion warning so it is only evaluated when `pooling_baseline != 2` (baseline present).
- Set `special_name` based on `stan_data$pooling_baseline`: `1` => `"log odds of event rate in untreated: mean"`, `0` => `"independent prior on control means (group-specific baseline log-odds)"`, `2` => `"DNP"` (suppressed), matching the existing `DNP` pattern used for `control_sd`.
- Changes are confined to `R/auto_prior.R` around the automated prior printout logic for `control`.

### Testing
- Attempted a syntax/parse check with `Rscript -e "parse(file='R/auto_prior.R')"`, but `Rscript` is not available in the environment so the check could not be completed.
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b29855780832a8d9fa8862baa2b2e)