### PR TITLE
Fix full-data CV logpd scale and add deterministic test

### DIFF
--- a/R/convert_inputs.R
+++ b/R/convert_inputs.R
@@ -205,17 +205,16 @@ convert_inputs <- function(data,
         # This array() is to ensure formatting for multi-arm experiments (but won't run with P > 1 for now)
         out$test_treatment <- array(test_data[[treatment]], c(out$N_test, out$P))
         out$test_site <- group_numeric_test
-        # calculate SEs in each test group
+        # calculate outcome SDs in each test group (used in predictive density)
         if(model %in% c("rubin_full", "mutau_full")){
-          se_in_each_group <- sapply(
+          sd_in_each_group <- sapply(
             1:max(group_numeric_test), function(i) {
-              n <- sum(group_numeric_test == i)
-              sd(test_data[[outcome]][group_numeric_test == i])/sqrt(n)
+              sd(test_data[[outcome]][group_numeric_test == i])
             })
-          if(any(is.na(se_in_each_group)))
-            stop("Cannot calculate SE in groups in test data. Each out-of-sample ",
+          if(any(is.na(sd_in_each_group)))
+            stop("Cannot calculate SD in groups in test data. Each out-of-sample ",
                  "group must be of size at least 2.")
-          out$test_sigma_y_k <- array(se_in_each_group, dim = max(group_numeric_test))
+          out$test_sigma_y_k <- array(sd_in_each_group, dim = max(group_numeric_test))
         }
       }
     }

--- a/inst/stan/mutau_full.stan
+++ b/inst/stan/mutau_full.stan
@@ -52,7 +52,7 @@ data {
   // NORMAL specific:
   vector[N] y;
   vector[N_test] test_y;
-  vector[K_test] test_sigma_y_k;
+  vector[K_test] test_sigma_y_k; // group-level outcome SDs in test data
 }
 
 transformed data {
@@ -134,7 +134,7 @@ model {
 }
 
 generated quantities {
-  // to do this, we must first (outside of Stan) calculate SEs in each test group,
+  // to do this, we must first (outside of Stan) calculate SDs in each test group,
   // i.e. test_sigma_y_k
   array[K_test > 0] real logpd;
   vector[N_test] fe_test;
@@ -154,4 +154,3 @@ generated quantities {
     }
   }
 }
-

--- a/inst/stan/rubin_full.stan
+++ b/inst/stan/rubin_full.stan
@@ -47,7 +47,7 @@ data {
   // NORMAL specific:
   array[N] real y;
   array[N_test] real test_y;
-  array[K_test] real test_sigma_y_k;
+  array[K_test] real test_sigma_y_k; // group-level outcome SDs in test data
   // priors on noise in regression:
   int prior_sigma_fam;
   vector[3] prior_sigma_val;
@@ -156,7 +156,7 @@ generated quantities {
                 + dot_product(test_treatment[i,], mu)
                 + (Nc > 0 ? dot_product(X_test[i,], beta) : 0.0);
 
-      // Compute the predictive standard deviation
+      // Compute the predictive SD (test_sigma_y_k is on outcome scale, not SE scale)
       if (pooling_type == 1) {
         sigma_pred = sqrt(dot_product(test_treatment[i,], tau .* tau) + test_sigma_y_k[test_site[i]]^2);
       } else if (pooling_type == 2) {

--- a/tests/testthat/test_full.R
+++ b/tests/testthat/test_full.R
@@ -151,6 +151,71 @@ test_that("rubin_full cross-validation works", {
   expect_gt(bg$mean_lpd, 0)
 })
 
+test_that("full-data test sigma uses SD and not SE", {
+  train <- data.frame(
+    group = rep("Train", 8),
+    outcome = c(-0.5, -0.2, 0.1, 0.4, 1.4, 1.8, 2.2, 2.5),
+    treatment = c(0, 0, 0, 0, 1, 1, 1, 1)
+  )
+  test <- data.frame(
+    group = rep(c("TestA", "TestB"), each = 4),
+    outcome = c(1, 2, 3, 4, 0.5, 1.5, 1.7, 2.3),
+    treatment = 1
+  )
+
+  expected_sd <- tapply(test$outcome, test$group, sd)
+
+  inp_rubin <- convert_inputs(train, model = "rubin_full", quantiles = seq(.05, .95, .1),
+                              test_data = test, outcome = "outcome",
+                              group = "group", treatment = "treatment")
+  inp_mutau <- convert_inputs(train, model = "mutau_full", quantiles = seq(.05, .95, .1),
+                              test_data = test, outcome = "outcome",
+                              group = "group", treatment = "treatment")
+
+  expect_equal(as.numeric(inp_rubin$test_sigma_y_k), as.numeric(expected_sd))
+  expect_equal(as.numeric(inp_mutau$test_sigma_y_k), as.numeric(expected_sd))
+})
+
+test_that("rubin_full predictive log density matches analytic Normal density scale", {
+  train <- data.frame(
+    group = c(rep("Train1", 8), rep("Train2", 8)),
+    outcome = c(-0.5, -0.2, 0.1, 0.4, 1.4, 1.8, 2.2, 2.5,
+                -0.3, 0.0, 0.2, 0.6, 1.1, 1.7, 2.0, 2.4),
+    treatment = c(rep(c(0, 0, 0, 0, 1, 1, 1, 1), 2))
+  )
+  test <- data.frame(
+    group = rep("Test", 4),
+    outcome = c(1, 2, 3, 4),
+    treatment = 1
+  )
+  test_sd <- sd(test$outcome)
+  test_se <- test_sd / sqrt(nrow(test))
+
+  bg <- expect_warning(
+    baggr(train,
+          model = "rubin_full",
+          pooling = "full",
+          pooling_control = "remove",
+          prior_hypermean = normal(0, 5),
+          prior_sigma = uniform(0.1, 5),
+          test_data = test,
+          iter = 250, warmup = 125, chains = 2, refresh = 0, seed = 137)
+  )
+
+  mu_draw <- rstan::extract(bg$fit, "mu")[[1]][,1]
+  logpd <- rstan::extract(bg$fit, "logpd[1]")[[1]]
+
+  expected_sd_logpd <- vapply(mu_draw, function(m) {
+    sum(dnorm(test$outcome, mean = m, sd = test_sd, log = TRUE))
+  }, numeric(1))
+  expected_se_logpd <- vapply(mu_draw, function(m) {
+    sum(dnorm(test$outcome, mean = m, sd = test_se, log = TRUE))
+  }, numeric(1))
+
+  expect_equal(as.numeric(logpd), as.numeric(expected_sd_logpd), tolerance = 1e-6)
+  expect_gt(mean(abs(logpd - expected_se_logpd)), 0.1)
+})
+
 
 
 # covariates ------


### PR DESCRIPTION
## Summary
- fix full-data cross-validation predictive scale for rubin_full and mutau_full
- use group-level outcome SD (not SE) when building test_sigma_y_k
- clarify Stan comments for test_sigma_y_k semantics
- add deterministic rubin_full test that validates logpd[1] against analytic Normal log-density
- add conversion test that test_sigma_y_k equals per-group sample SD

## Verification
- NOT_CRAN=true Rscript -e 'Sys.setenv("PKG_BUILD_EXTRA_FLAGS"="false"); pkgload::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test_full.R")'
- NOT_CRAN=true Rscript -e 'Sys.setenv("PKG_BUILD_EXTRA_FLAGS"="false"); pkgload::load_all(quiet=TRUE); testthat::test_dir("tests/testthat", filter = "mutau|loo|helpers", reporter = "summary")'