### PR TITLE
Fix prior conflict check typo for prior_cluster

### DIFF
--- a/R/baggr.R
+++ b/R/baggr.R
@@ -363,7 +363,7 @@ baggr <- function(data,
                   selection = prior_selection
                   )
   } else {
-    if(!is.null(prior_hypermean) || !is.null(prior_beta) || is.null(prior_cluster) ||
+    if(!is.null(prior_hypermean) || !is.null(prior_beta) || !is.null(prior_cluster) ||
        !is.null(prior_control)   || !is.null(prior_control_sd) ||
        !is.null(prior_hypercor)  || !is.null(prior_hypersd))
       message("Both 'prior$' and 'prior_' arguments specified. Using 'prior' only.")

--- a/tests/testthat/test_prior.R
+++ b/tests/testthat/test_prior.R
@@ -23,6 +23,23 @@ test_that("Wrong prior specifications crash baggr()", {
 
 test_that("Prior specification via different arguments", {
   custom_prior <- list(hypermean = normal(0, 10), hypersd = uniform(0, 20))
+  expect_message(
+    suppressWarnings(
+      baggr(df_pooled, "rubin",
+            iter = 20, chains = 1, refresh = 0, seed = 1990,
+            prior = custom_prior)
+    ),
+    NA
+  )
+  expect_message(
+    suppressWarnings(
+      baggr(df_pooled, "rubin",
+            iter = 20, chains = 1, refresh = 0, seed = 1990,
+            prior_hypermean = normal(0, 2),
+            prior = custom_prior)
+    ),
+    "Both 'prior\\$' and 'prior_' arguments specified. Using 'prior' only."
+  )
   bg_prior1 <- expect_warning(baggr(df_pooled, "rubin",
                                     iter = 200, chains = 2, refresh = 0, seed = 1990,
                                     prior_hypermean = normal(0, 2),


### PR DESCRIPTION
## Summary
- fix typo in prior-conflict detection in baggr() by changing the prior_cluster condition to !is.null(prior_cluster)
- prevent false message "Both 'prior$' and 'prior_' arguments specified" when only prior=list(...) is used
- add regression tests for no-message (prior-only) and conflict-message (prior + prior_hypermean)

## Verification
- NOT_CRAN=true Rscript -e 'Sys.setenv("PKG_BUILD_EXTRA_FLAGS"="false"); pkgload::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test_prior.R")'