### PR TITLE
Fix Windows GHA Codecov guard shell parsing

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,6 +32,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Guard against hard-coded Codecov tokens
+        shell: bash
+        run: |
+          if grep -RInE 'covr::codecov\([^)]*token[[:space:]]*=' tools R .github; then
+            echo "Hard-coded Codecov token usage detected. Use CODECOV_TOKEN secret."
+            exit 1
+          fi
+
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+- For future R package compilations via `devtools::load_all()` or `pkgload::load_all()`, always set `quiet = TRUE` unless the user explicitly asks for verbose compiler output.
+- Before recompiling or calling `devtools::load_all()` / `pkgload::load_all()`, run `Sys.setenv(PKG_BUILD_EXTRA_FLAGS = "false")`.
+- All fixes must be implemented on new branches created from `devel`.


### PR DESCRIPTION
Summary
- add a guard step to prevent hard-coded covr::codecov token usage
- force that guard step to run with shell bash so windows-latest does not parse it as PowerShell
- add AGENTS policy: all fixes must use new branches from devel

Why
The guard used Bash syntax (if grep ...) and failed on Windows runners when interpreted by PowerShell.

Files
- .github/workflows/R-CMD-check.yaml
- AGENTS.md