### PR TITLE
Fix Rubin full/none pooling hypersd prior handling

### DIFF
--- a/tests/testthat/test_onerow.R
+++ b/tests/testthat/test_onerow.R
@@ -35,6 +35,13 @@ test_that("The thing runs", {
   expect_is(bg_onerow_p, "baggr")
   expect_is(bg_onerow_n, "baggr")
   expect_is(bg_onerow_binary, "baggr")
+  expect_no_error(
+    suppressWarnings(
+      baggr(df_pooled[1,], pooling = "full", group = "state",
+            iter = 50, chains = 1, refresh = 0,
+            show_messages = F)
+    )
+  )
 
   expect_error(baggr(df_pooled[1,], pooling = "partial", group = "state",
                      iter = 200, chains = 2, refresh = 0,
@@ -52,7 +59,6 @@ test_that("The thing runs", {
   expect_is(gg1, "gg")
   expect_is(gg2, "gg")
 })
-
 
 
 


### PR DESCRIPTION
## Summary
- fix Rubin prior preparation so hyper-SD is only active for partial pooling
- avoid false one-row hyper-SD error when pooling = "full"
- suppress misleading auto hyper-SD messages when pooling != "partial"
- for non-partial pooling, keep Stan placeholder prior values but omit hypersd from user-facing prior_dist
- add regression tests covering one-row full pooling, fe7n/fe8u workflow, and non-partial prior/message behavior

## Verification
- NOT_CRAN=true Rscript -e 'Sys.setenv("PKG_BUILD_EXTRA_FLAGS"="false"); pkgload::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test_onerow.R")'
- NOT_CRAN=true Rscript -e 'Sys.setenv("PKG_BUILD_EXTRA_FLAGS"="false"); pkgload::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test_rubin.R")'

Fixes #178