### PR TITLE
Fix mutau full-pooling print correlation path

### DIFF
--- a/R/print_baggr.R
+++ b/R/print_baggr.R
@@ -95,7 +95,7 @@ print.baggr <- function(x,
               tot_pool[1], "to", tot_pool[3], "\n")
       }
 
-      if(x$model == "mutau") {
+      if(x$model == "mutau" && x$pooling != "full") {
         mutauc <- format(mutau_cor(x, summary = TRUE, interval=prob),
                          digits = digits, trim = TRUE)
         cat("Correlation of treatment effect and baseline =", mutauc[2], intervaltxt,

--- a/tests/testthat/test_mutau.R
+++ b/tests/testthat/test_mutau.R
@@ -171,6 +171,12 @@ test_that("Extracting treatment/study effects works", {
   expect_message(treatment_effect(bg5_n), "no treatment effect estimated when")
 })
 
+test_that("printing fully pooled mutau omits undefined correlation", {
+  full_print <- capture_output(print(bg5_f))
+  expect_type(full_print, "character")
+  expect_true(!any(grepl("Correlation of treatment effect and baseline", full_print)))
+})
+
 comp_mt <- baggr_compare(
   bg5_p, bg5_f
 )
@@ -185,4 +191,3 @@ test_that("baggr comparison method works for mu-tau models", {
   expect_is(plot(comp_mt, grid_models = TRUE), "gtable")
 
 })
-


### PR DESCRIPTION
## Summary
- avoid calling mutau_cor() when printing a mutau model with pooling = "full"
- keep correlation output for non-full pooling where L_Omega exists
- add a regression test asserting full-pooled mutau printing does not include correlation text and does not error

## Testing
- Rscript -e 'Sys.setenv(PKG_BUILD_EXTRA_FLAGS="false"); pkgload::load_all(quiet=TRUE); testthat::test_file("tests/testthat/test_mutau.R")'
