### PR TITLE
Fix prior_sigma wiring and numeric-column validation message

### DIFF
--- a/R/baggr.R
+++ b/R/baggr.R
@@ -360,19 +360,20 @@ baggr <- function(data,
                   cluster   = prior_cluster,
                   control   = prior_control,
                   control_sd= prior_control_sd,
+                  sigma     = prior_sigma,
                   selection = prior_selection
                   )
   } else {
     if(!is.null(prior_hypermean) || !is.null(prior_beta) || !is.null(prior_cluster) ||
-       !is.null(prior_control)   || !is.null(prior_control_sd) ||
+       !is.null(prior_control)   || !is.null(prior_control_sd) || !is.null(prior_sigma) ||
        !is.null(prior_hypercor)  || !is.null(prior_hypersd))
       message("Both 'prior$' and 'prior_' arguments specified. Using 'prior' only.")
     if(!inherits(prior, "list") ||
        !all(names(prior) %in% c('hypermean', 'hypercor', 'hypersd', 'cluster',
-                                'beta', 'control', 'control_sd')))
+                                'beta', 'control', 'control_sd', 'sigma', 'selection')))
       warning(paste("Only names used in the prior argument are:",
                     "'hypermean', 'hypercor', 'hypersd', 'cluster',
-                    'beta', 'control', 'control_sd'"))
+                    'beta', 'control', 'control_sd', 'sigma', 'selection'"))
   }
 
   # If extracting prior from another model, we need to do this switcheroo:

--- a/R/check_cols.R
+++ b/R/check_cols.R
@@ -3,7 +3,7 @@
 check_columns_numeric <- function(data) {
   numcols <- unlist(lapply(data, is.numeric))
   if(sum(!numcols) > 0)
-    stop(paste("Column(s)", paste(names(numcols)[numcols], collapse = ","), "are not numeric"))
+    stop(paste("Column(s)", paste(names(numcols)[!numcols], collapse = ","), "are not numeric"))
 }
 
 check_columns_ipd <- function(data, outcome, group, treatment,

--- a/tests/testthat/test_prior.R
+++ b/tests/testthat/test_prior.R
@@ -70,6 +70,48 @@ test_that("Prior specification via different arguments", {
                  "names used in the prior")
 })
 
+test_that("prior_sigma is wired via prior_ arguments and sigma/selection names are accepted", {
+  df_full <- data.frame(
+    group = c("A", "A", "A", "A", "B", "B", "B", "B"),
+    treatment = c(0, 0, 1, 1, 0, 0, 1, 1),
+    outcome = c(0.1, 0.2, 0.4, 0.5, -0.2, -0.1, 0.2, 0.3),
+    stringsAsFactors = FALSE
+  )
+
+  expect_message(
+    expect_error(
+      baggr(df_full,
+            model = "rubin_full",
+            prior = list(hypermean = lkj(2)),
+            prior_sigma = uniform(0.1, 1),
+            iter = 10, chains = 1, refresh = 0, seed = 19),
+      "Prior for hypermean must be one of the following"
+    ),
+    "Both 'prior\\$' and 'prior_' arguments specified. Using 'prior' only."
+  )
+
+  expect_warning(
+    expect_error(
+      baggr(df_full,
+            model = "rubin_full",
+            prior = list(hypermean = lkj(2), sigma = uniform(0.1, 1), selection = normal(0, 1)),
+            iter = 10, chains = 1, refresh = 0, seed = 19),
+      "Prior for hypermean must be one of the following"
+    ),
+    NA
+  )
+
+  expect_error(
+    baggr(df_full,
+          model = "rubin_full",
+          prior_hypermean = normal(0, 1),
+          prior_hypersd = normal(0, 1),
+          prior_sigma = lkj(2),
+          iter = 10, chains = 1, refresh = 0, seed = 19),
+    "Prior for sigma must be one of the following"
+  )
+})
+
 test_that("All possible prior dist's work", {
   expect_is(normal(0, 10), "list")
   expect_is(cauchy(0, 10), "list")

--- a/tests/testthat/test_selection_and_validation.R
+++ b/tests/testthat/test_selection_and_validation.R
@@ -64,6 +64,20 @@ test_that("check_columns_ipd() validates columns and argument types", {
   )
 })
 
+test_that("check_columns_numeric() reports non-numeric columns", {
+  dat <- data.frame(
+    ok = c(1, 2),
+    bad_chr = c("x", "y"),
+    bad_lgl = c(TRUE, FALSE),
+    stringsAsFactors = FALSE
+  )
+
+  expect_error(
+    baggr:::check_columns_numeric(dat),
+    "Column\\(s\\) bad_chr,bad_lgl are not numeric"
+  )
+})
+
 test_that("loo_compare and print methods work with synthetic baggr_cv objects", {
   mk_cv <- function(pointwise) {
     structure(list(


### PR DESCRIPTION
## Summary

This PR fixes two correctness issues:
- wire `prior_sigma` through `baggr()` when using `prior_` arguments
- fix `check_columns_numeric()` so it reports non-numeric columns correctly

## Changes

- add `sigma = prior_sigma` to internal prior assembly in `R/baggr.R`
- include `prior_sigma` in the prior conflict check
- allow `sigma` and `selection` names in `prior = list(...)` validation and warning text
- fix offending-column selection in `R/check_cols.R` from `names(numcols)[numcols]` to `names(numcols)[!numcols]`
- add regression tests in `tests/testthat/test_prior.R` and `tests/testthat/test_selection_and_validation.R`

## Validation

Ran:
- `Sys.setenv(PKG_BUILD_EXTRA_FLAGS="false")`
- `pkgload::load_all(".", quiet=TRUE)`
- `testthat::test_file("tests/testthat/test_prior.R")`
- `testthat::test_file("tests/testthat/test_selection_and_validation.R")`

Both targeted test files pass.