### PR TITLE
Warn on covariates constant within every site for rubin_full

### DIFF
--- a/R/baggr.R
+++ b/R/baggr.R
@@ -138,7 +138,10 @@
 #' * In `"logit"` and `"rubin_full"` models, covariates that __change according to individual unit__.
 #'   Then, such a model is often referred to as a mixed model. It has to be
 #'   fitted to individual-level data. Note that meta-regression is a special
-#'   case of a mixed model for individual-level data.
+#'   case of a mixed model for individual-level data. For `"rubin_full"`,
+#'   covariates that are constant within every site are aliased with
+#'   site-specific baselines and should be removed or handled by changing
+#'   baseline pooling.
 #'
 #'
 #' __Priors.__ It is optional to specify priors yourself,

--- a/R/convert_inputs.R
+++ b/R/convert_inputs.R
@@ -354,6 +354,9 @@ convert_inputs <- function(data,
                   paste(covariates[!(covariates %in% names(data))], collapse=","),
                   " are not columns in input data"))
 
+    if(model == "rubin_full")
+      .warn_constant_within_site_covariates(data, covariates, group)
+
     for(cov in covariates)
       if(any(is.na(data[[cov]])))
         stop("NA values present in covariates")
@@ -362,7 +365,7 @@ convert_inputs <- function(data,
     # This indicates if the model can be interpreted as a meta-regression.
     if(grepl("individual", required_data)) {
       covariate_is_fixed <- vapply(covariates, function(cov) {
-        all(tapply(data[[cov]], data[[group]], function(x) length(unique(x)) == 1))
+        all(tapply(data[[cov]], data[[group]], function(x) length(unique(x[!is.na(x)])) <= 1))
       }, logical(1))
       varying_covariates <- covariates[!covariate_is_fixed]
       for(cov in varying_covariates)
@@ -458,6 +461,26 @@ convert_inputs <- function(data,
     effect = effect)
 
   return(out_structure)
+}
+
+.warn_constant_within_site_covariates <- function(data, covariates, group) {
+  if(length(covariates) == 0)
+    return(invisible(character(0)))
+
+  constant_covariates <- vapply(covariates, function(cov) {
+    distinct_by_site <- tapply(data[[cov]], data[[group]], function(x) {
+      length(unique(x[!is.na(x)]))
+    })
+    all(distinct_by_site <= 1)
+  }, logical(1))
+
+  flagged_covariates <- covariates[constant_covariates]
+  if(length(flagged_covariates) > 0)
+    warning("covariates ", paste(flagged_covariates, collapse = ", "),
+            " are constant within every site, please adjust pooling baseline behaviour or remove covariates",
+            call. = FALSE)
+
+  invisible(flagged_covariates)
 }
 
 normalise_selection <- function(selection, K) {

--- a/man/baggr.Rd
+++ b/man/baggr.Rd
@@ -195,7 +195,10 @@ model. It can be modelled on summary-level data.
 \item In \code{"logit"} and \code{"rubin_full"} models, covariates that \strong{change according to individual unit}.
 Then, such a model is often referred to as a mixed model. It has to be
 fitted to individual-level data. Note that meta-regression is a special
-case of a mixed model for individual-level data.
+case of a mixed model for individual-level data. For \code{"rubin_full"},
+covariates that are constant within every site are aliased with
+site-specific baselines and should be removed or handled by changing
+baseline pooling.
 }
 
 \strong{Priors.} It is optional to specify priors yourself,

--- a/tests/testthat/test_full.R
+++ b/tests/testthat/test_full.R
@@ -255,6 +255,64 @@ sa$c <- sample(c("A", "B", "C"), nrow(schools_ipd), replace = T)
 sb <- sa
 sb$b <- NULL
 
+test_that("rubin_full warns about covariates constant within every site", {
+  site_cov <- data.frame(
+    group = rep(1:2, each = 2),
+    x = c(0, 0, 1, 1)
+  )
+
+  expect_warning(
+    .warn_constant_within_site_covariates(site_cov, "x", "group"),
+    "covariates x are constant within every site"
+  )
+})
+
+test_that("rubin_full does not warn when covariate varies within a site", {
+  individual_cov <- data.frame(
+    group = rep(1:2, each = 2),
+    x = c(0, 1, 1, 1)
+  )
+
+  expect_warning(
+    .warn_constant_within_site_covariates(individual_cov, "x", "group"),
+    NA
+  )
+})
+
+test_that("rubin_full constant within-site covariate warning names only bad covariates", {
+  mixed_cov <- data.frame(
+    group = rep(1:2, each = 2),
+    x = c(0, 0, 1, 1),
+    z = c(0, 1, 1, 1)
+  )
+
+  expect_warning(
+    .warn_constant_within_site_covariates(mixed_cov, c("x", "z"), "group"),
+    regexp = "covariates x are constant within every site"
+  )
+  warning_msg <- NULL
+  withCallingHandlers(
+    .warn_constant_within_site_covariates(mixed_cov, c("x", "z"), "group"),
+    warning = function(w) {
+      warning_msg <<- conditionMessage(w)
+      invokeRestart("muffleWarning")
+    }
+  )
+  expect_match(warning_msg, "covariates x are constant within every site")
+  expect_false(grepl("z", warning_msg, fixed = TRUE))
+})
+
+test_that("rubin_full constant within-site covariate warning ignores missing values", {
+  missing_cov <- data.frame(
+    group = rep(1:2, each = 2),
+    x = c(0, NA, 1, NA)
+  )
+
+  expect_warning(
+    .warn_constant_within_site_covariates(missing_cov, "x", "group"),
+    "covariates x are constant within every site"
+  )
+})
 
 test_that("Model with covariates works fine", {
   bg_cov <- expect_warning(


### PR DESCRIPTION
### Motivation
- Prevent users from passing covariates to the `rubin_full` model that are effectively aliased with site-specific baselines because they are constant within every site, which leads to weak identification or perfect aliasing depending on `pooling_control`.

### Description
- Add a helper `.warn_constant_within_site_covariates()` in `R/convert_inputs.R` that computes the number of distinct non-missing values per site for each covariate and flags covariates that have at most one distinct non-missing value in every site, then emits the requested warning text naming only the flagged covariates.
- Call the helper prior to fitting when `model == "rubin_full"` and update the meta-regression fixed-vs-varying check to ignore missing values when counting within-site distinctness. (Changes in `R/convert_inputs.R`.)
- Add a short explanatory sentence to the covariates documentation where `rubin_full` is discussed so users are informed that covariates constant within every site are aliased with site baselines. (Changes in `R/baggr.R` and `man/baggr.Rd`.)
- Add four fast unit tests in `tests/testthat/test_full.R` that cover: a site-level covariate that should warn, an individual-level covariate that should not warn, multiple covariates where only the bad ones are reported, and that missing values are ignored in the check.

### Testing
- Added unit tests covering the four specified scenarios in `tests/testthat/test_full.R` (site-level warn, within-site variation no-warn, mixed covariates, missing-values ignored). 
- Attempted to run the test subset with `devtools::test(filter = "full")`, but the test run could not be executed in the environment because R is not installed (`R: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ec069b38c832a859aba2f263d5b3e)