### PR TITLE
Fix #143: clarify transform documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@ Functionality:
 Documentation:
 
 - Added a vignette `baggr_selection` that has examples of how to do selection models
+- Clarified how `transform` is applied in `treatment_effect()`, `hypermean()`,
+  `hypersd()`, and `effect_draw()` (#143)
 
 Fixes: 
 

--- a/R/effect_draw.R
+++ b/R/effect_draw.R
@@ -8,6 +8,11 @@
 #' This can be used for both prior and posterior draws, depending on [baggr::baggr()] model.
 #' By default this is done for a single new effect, but for meta-regression models
 #' you can specify values of covariates with the `newdata` argument, same as in [predict.baggr].
+#' If `transform` is supplied, it is applied after drawing from this predictive
+#' distribution. For example, `effect_draw(bg, transform = exp)` for a model fit
+#' on a log scale returns predictive draws on the ratio scale. This is not the
+#' same object as `hypermean(bg, transform = exp)`: `effect_draw()` also includes
+#' the uncertainty or heterogeneity around the mean treatment effect.
 #'
 #' @param object A `baggr` class object.
 #' @param draws How many values to draw? The default is as long as the number of samples
@@ -50,6 +55,16 @@
 #' the predicted values can be adjusted for known levels of fixed covariates by
 #' passing `newdata` (same as in [predict.baggr]). If no adjustment is made, the
 #' returned value should be interpreted as the effect when all covariates are 0.
+#'
+#' @examples
+#' \donttest{
+#' # Fit on a log scale, then exponentiate predictive draws to obtain ratios.
+#' log_rr <- data.frame(tau = log(c(0.7, 0.9, 1.1, 1.3)),
+#'                      se = c(0.2, 0.25, 0.3, 0.35))
+#' bg_log <- baggr(log_rr, pooling = "partial", iter = 500, refresh = 0)
+#'
+#' effect_draw(bg_log, transform = exp)
+#' }
 #'
 #' @references
 #' Riley, Richard D., Julian P. T. Higgins, and Jonathan J. Deeks.

--- a/R/trt_effects.R
+++ b/R/trt_effects.R
@@ -4,6 +4,17 @@
 #' The most general `treatment_effect` displays
 #' both hypermean and hyperSD (as a list of length 2),
 #' whereas `hypermean` and `hypersd` can be used as shorthands.
+#' The `transform` argument applies to posterior draws of model parameters:
+#' for example, `hypermean(bg, transform = exp)` exponentiates only the
+#' posterior distribution of the mean treatment effect. This is useful when a
+#' model was fit on a transformed scale, such as a log risk ratio or log odds
+#' ratio scale. It is different from [effect_draw()], which first draws from
+#' the posterior predictive distribution of a new treatment effect, including
+#' heterogeneity or uncertainty around the mean, and then applies the
+#' transformation. Because a transformed hyper-SD is not generally
+#' interpretable, `treatment_effect()` returns `sigma_tau = NA` when
+#' `transform` is supplied; this is also what `hypersd(bg, transform = ...)`
+#' returns.
 #'
 #' @param bg a [baggr::baggr()] model
 #' @param summary logical; if TRUE returns summary statistics as explained below.
@@ -19,6 +30,15 @@
 #'         `interval`
 #' @export
 #' @importFrom rstan extract
+#' @examples
+#' \donttest{
+#' # Fit on a log scale, then exponentiate the hypermean draws to obtain ratios.
+#' log_rr <- data.frame(tau = log(c(0.7, 0.9, 1.1, 1.3)),
+#'                      se = c(0.2, 0.25, 0.3, 0.35))
+#' bg_log <- baggr(log_rr, pooling = "partial", iter = 500, refresh = 0)
+#'
+#' hypermean(bg_log, transform = exp)
+#' }
 
 
 treatment_effect <- function(bg, summary = FALSE,
@@ -134,4 +154,3 @@ mutau_cor <- function(bg,
     return(m[,2])
 
 }
-

--- a/man/effect_draw.Rd
+++ b/man/effect_draw.Rd
@@ -47,6 +47,11 @@ and draws values of new realisations of treatment effect, i.e. an additional dra
 This can be used for both prior and posterior draws, depending on \code{\link[=baggr]{baggr()}} model.
 By default this is done for a single new effect, but for meta-regression models
 you can specify values of covariates with the \code{newdata} argument, same as in \link{predict.baggr}.
+If \code{transform} is supplied, it is applied after drawing from this predictive
+distribution. For example, \code{effect_draw(bg, transform = exp)} for a model fit
+on a log scale returns predictive draws on the ratio scale. This is not the
+same object as \code{hypermean(bg, transform = exp)}: \code{effect_draw()} also includes
+the uncertainty or heterogeneity around the mean treatment effect.
 }
 \details{
 The predictive distribution can be used to "combine" heterogeneity between treatment effects and
@@ -69,6 +74,17 @@ If the \code{baggr} model used by the function is a meta-regression
 the predicted values can be adjusted for known levels of fixed covariates by
 passing \code{newdata} (same as in \link{predict.baggr}). If no adjustment is made, the
 returned value should be interpreted as the effect when all covariates are 0.
+}
+\examples{
+\donttest{
+# Fit on a log scale, then exponentiate predictive draws to obtain ratios.
+log_rr <- data.frame(tau = log(c(0.7, 0.9, 1.1, 1.3)),
+                     se = c(0.2, 0.25, 0.3, 0.35))
+bg_log <- baggr(log_rr, pooling = "partial", iter = 500, refresh = 0)
+
+effect_draw(bg_log, transform = exp)
+}
+
 }
 \references{
 Riley, Richard D., Julian P. T. Higgins, and Jonathan J. Deeks.

--- a/man/treatment_effect.Rd
+++ b/man/treatment_effect.Rd
@@ -42,6 +42,17 @@ no pooling models}
 The most general \code{treatment_effect} displays
 both hypermean and hyperSD (as a list of length 2),
 whereas \code{hypermean} and \code{hypersd} can be used as shorthands.
+The \code{transform} argument applies to posterior draws of model parameters:
+for example, \code{hypermean(bg, transform = exp)} exponentiates only the
+posterior distribution of the mean treatment effect. This is useful when a
+model was fit on a transformed scale, such as a log risk ratio or log odds
+ratio scale. It is different from \code{\link[=effect_draw]{effect_draw()}}, which first draws from
+the posterior predictive distribution of a new treatment effect, including
+heterogeneity or uncertainty around the mean, and then applies the
+transformation. Because a transformed hyper-SD is not generally
+interpretable, \code{treatment_effect()} returns \code{sigma_tau = NA} when
+\code{transform} is supplied; this is also what \code{hypersd(bg, transform = ...)}
+returns.
 }
 \section{Functions}{
 \itemize{
@@ -55,3 +66,13 @@ both vectors are summarised as mean and lower/upper bounds according to
 \item \code{hypersd()}: The hyper-SD of a \code{baggr} model, shorthand for \code{treatment_effect(x, s=T)[[2]]}
 
 }}
+\examples{
+\donttest{
+# Fit on a log scale, then exponentiate the hypermean draws to obtain ratios.
+log_rr <- data.frame(tau = log(c(0.7, 0.9, 1.1, 1.3)),
+                     se = c(0.2, 0.25, 0.3, 0.35))
+bg_log <- baggr(log_rr, pooling = "partial", iter = 500, refresh = 0)
+
+hypermean(bg_log, transform = exp)
+}
+}


### PR DESCRIPTION
## Summary

- Clarifies that `treatment_effect()` and `hypermean()` transform posterior parameter draws, while `effect_draw()` transforms posterior predictive draws after adding heterogeneity or uncertainty around the mean.
- Documents the existing `hypersd(..., transform = ...)` behavior and adds short `exp` examples for log-scale fits.
- Updates generated Rd pages and NEWS.md.

## Tests

- `Rscript --vanilla -e 'Sys.setenv(PKG_BUILD_EXTRA_FLAGS = "false"); roxygen2::roxygenise()'` — regenerated affected Rd pages
- `Rscript --vanilla -e 'tools::checkRd("man/treatment_effect.Rd"); tools::checkRd("man/effect_draw.Rd")'` — passed
- `git diff --check -- NEWS.md R/effect_draw.R R/trt_effects.R man/effect_draw.Rd man/treatment_effect.Rd` — passed

## Notes

Documentation-only change; no package tests or model fits were run locally.

Closes #143.